### PR TITLE
fix: resolve all 16 open GitHub issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ gdauto is an agent-native command-line tool for the Godot game engine. Built in 
 - **Engine compatibility**: Godot 4.5+ binary on PATH (for E2E tests and headless commands only)
 - **Independence**: No Godot dependency for file manipulation commands (sprite, tileset, resource inspect)
 - **License**: Apache-2.0
-- **Error contract**: All errors produce non-zero exit codes and actionable messages; --json errors produce `{"error": "message", "code": "ERROR_CODE"}`
+- **Error contract**: All errors produce non-zero exit codes and actionable messages; --json errors produce `{"error": "message", "code": "ERROR_CODE", "fix": "suggestion"}`
 - **File validity**: Generated .tres/.tscn files must be loadable by Godot without modification
 - **Code style**: No em dashes (use commas, colons, semicolons, parentheses), no emojis, type hints on all signatures, docstrings on public functions, functions under 30 lines, comments on non-obvious logic only
 <!-- GSD:project-end -->

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Every command supports:
 | `--no-color` | | Disable colored output |
 | `--godot-path` | | Explicit Godot binary path |
 
-All errors produce non-zero exit codes. With `--json`, errors return `{"error": "message", "code": "ERROR_CODE"}` with actionable fix suggestions.
+All errors produce non-zero exit codes. With `--json`, errors return `{"error": "message", "code": "ERROR_CODE", "fix": "suggestion"}` to stderr with actionable fix suggestions.
 
 ## Architecture
 

--- a/src/gdauto/commands/project.py
+++ b/src/gdauto/commands/project.py
@@ -12,7 +12,7 @@ from rich.table import Table
 
 from gdauto.backend import GodotBackend
 from gdauto.errors import GodotBinaryError, ProjectError
-from gdauto.formats.project_cfg import parse_project_config
+from gdauto.formats.project_cfg import parse_project_config, serialize_project_config
 from gdauto.formats.tscn import parse_tscn_file
 from gdauto.formats.tres import parse_tres_file
 from gdauto.output import GlobalConfig, emit, emit_error
@@ -53,6 +53,19 @@ def _strip_quotes(value: str) -> str:
     return value
 
 
+def _extract_godot_version(features: str) -> str | None:
+    """Extract engine version from features PackedStringArray.
+
+    The features string looks like: PackedStringArray("4.5", "GL Compatibility")
+    The first quoted element that looks like a version number is the engine version.
+    """
+    import re
+    match = re.search(r'PackedStringArray\("([0-9]+\.[0-9]+[^"]*)"', features)
+    if match:
+        return match.group(1)
+    return None
+
+
 def _extract_info(config_text: str) -> dict[str, Any]:
     """Parse project.godot text and extract project metadata."""
     cfg = parse_project_config(config_text)
@@ -70,12 +83,12 @@ def _extract_info(config_text: str) -> dict[str, Any]:
 
     features = cfg.get_value("application", "config/features") or ""
 
-    # Extract autoloads
+    # Extract autoloads, stripping the * singleton prefix for clean paths
     autoloads: dict[str, str] = {}
     autoload_section = cfg.sections.get("autoload")
     if autoload_section:
         for key, val in autoload_section:
-            clean_val = _strip_quotes(val)
+            clean_val = _strip_quotes(val).lstrip("*")
             autoloads[key] = clean_val
 
     # Extract display settings
@@ -90,9 +103,12 @@ def _extract_info(config_text: str) -> dict[str, Any]:
     if stretch:
         display["stretch_mode"] = _strip_quotes(stretch)
 
+    godot_version = _extract_godot_version(features)
+
     return {
         "name": name,
         "config_version": config_version,
+        "godot_version": godot_version,
         "main_scene": main_scene,
         "icon": icon,
         "features": features,
@@ -106,6 +122,8 @@ def _display_project_info_human(data: dict[str, Any], verbose: bool = False) -> 
     console = Console()
     console.print(f"[bold]Project:[/bold] {data['name']}")
     console.print(f"  Config version: {data['config_version']}")
+    if data.get("godot_version"):
+        console.print(f"  Godot version: {data['godot_version']}")
     console.print(f"  Main scene: {data['main_scene']}")
     console.print(f"  Icon: {data['icon']}")
     console.print(f"  Features: {data['features']}")
@@ -185,6 +203,32 @@ def _extract_res_refs(text: str, refs: set[str]) -> None:
         refs.add(match.group(0))
 
 
+def _check_project_godot_refs(
+    cfg: Any, project_root: Path, missing: list[str]
+) -> None:
+    """Check res:// paths referenced in project.godot against the filesystem."""
+    # Check main_scene and icon from [application]
+    for key in ("run/main_scene", "config/icon"):
+        val = cfg.get_value("application", key)
+        if val is None:
+            continue
+        clean = _strip_quotes(val)
+        if clean.startswith("res://"):
+            rel = clean.replace("res://", "", 1)
+            if not (project_root / rel).exists() and clean not in missing:
+                missing.append(clean)
+
+    # Check autoload paths
+    autoload_section = cfg.sections.get("autoload")
+    if autoload_section:
+        for _key, val in autoload_section:
+            clean = _strip_quotes(val).lstrip("*")
+            if clean.startswith("res://"):
+                rel = clean.replace("res://", "", 1)
+                if not (project_root / rel).exists() and clean not in missing:
+                    missing.append(clean)
+
+
 def _collect_orphan_scripts(
     project_root: Path, all_refs: set[str]
 ) -> list[str]:
@@ -247,14 +291,28 @@ def validate(ctx: click.Context, path: str, check_only: bool) -> None:
         project_root = project_godot.parent
 
         missing, all_refs = _collect_res_paths(project_root)
+
+        # Also check resource references inside project.godot
+        config_text = project_godot.read_text(encoding="utf-8")
+        cfg = parse_project_config(config_text)
+        _check_project_godot_refs(cfg, project_root, missing)
+
+        # Include autoload scripts so they are not reported as orphans
+        autoload_section = cfg.sections.get("autoload")
+        if autoload_section:
+            for _key, val in autoload_section:
+                clean = _strip_quotes(val).lstrip("*")
+                if clean.startswith("res://"):
+                    all_refs.add(clean)
+
         orphans = _collect_orphan_scripts(project_root, all_refs)
 
-        # Count files scanned
+        # Count files scanned (project.godot counts as +1)
         scanned = sum(
             1 for _ in project_root.rglob("*.tscn")
         ) + sum(
             1 for _ in project_root.rglob("*.tres")
-        )
+        ) + 1
 
         report: dict[str, Any] = {
             "missing_resources": missing,
@@ -282,7 +340,22 @@ def _run_check_only(
     report: dict[str, Any],
 ) -> None:
     """Run Godot --check-only and add script errors to report."""
-    config: GlobalConfig = ctx.obj
+    # Check if any .gd scripts exist
+    gd_files = list(project_root.rglob("*.gd"))
+    if not gd_files:
+        report["script_errors"] = []
+        report["godot_check_skipped"] = True
+        report["godot_check_skip_reason"] = "no .gd scripts found"
+        config: GlobalConfig = ctx.obj
+        if not config.json_mode and not config.quiet:
+            click.echo(
+                "Note: --check-only requested but no .gd scripts found; "
+                "Godot syntax check skipped",
+                err=True,
+            )
+        return
+
+    config = ctx.obj
     try:
         backend = GodotBackend(binary_path=config.godot_path)
         result = backend.check_only(project_root)
@@ -293,10 +366,19 @@ def _run_check_only(
                 if "error" in line.lower():
                     errors.append(line.strip())
         report["script_errors"] = errors
+        report["godot_check_skipped"] = False
         report["issues_found"] += len(errors)
     except GodotBinaryError:
         # Godot not available; continue with file-level checks only
         report["script_errors"] = []
+        report["godot_check_skipped"] = True
+        report["godot_check_skip_reason"] = "Godot binary not available"
+        if not config.json_mode and not config.quiet:
+            click.echo(
+                "Note: --check-only requested but Godot binary not found; "
+                "syntax check skipped",
+                err=True,
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -416,3 +498,108 @@ def _scaffold_project(target: Path, name: str) -> list[str]:
     created.append(".gdignore")
 
     return created
+
+
+# ---------------------------------------------------------------------------
+# project add-autoload
+# ---------------------------------------------------------------------------
+
+
+@project.command("add-autoload")
+@click.option(
+    "--name", required=True,
+    help="Autoload singleton name (e.g., GameState)",
+)
+@click.option(
+    "--path", "script_path", required=True,
+    help="Godot res:// path to the script (e.g., res://scripts/game_state.gd)",
+)
+@click.option(
+    "--no-singleton", is_flag=True, default=False,
+    help="Register without the singleton '*' prefix",
+)
+@click.argument("project_path", default=".", type=click.Path())
+@click.pass_context
+def add_autoload(
+    ctx: click.Context,
+    name: str,
+    script_path: str,
+    no_singleton: bool,
+    project_path: str,
+) -> None:
+    """Register an autoload singleton in project.godot."""
+    try:
+        project_godot = _find_project_godot(project_path)
+        config_text = project_godot.read_text(encoding="utf-8")
+        cfg = parse_project_config(config_text)
+
+        # Check for duplicates
+        existing = cfg.sections.get("autoload", [])
+        for key, _val in existing:
+            if key == name:
+                raise ProjectError(
+                    message=f"Autoload '{name}' already exists",
+                    code="AUTOLOAD_EXISTS",
+                    fix=f"Remove the existing autoload or choose a different name",
+                )
+
+        # Build the value with or without singleton prefix
+        prefix = "" if no_singleton else "*"
+        value = f'"{prefix}{script_path}"'
+
+        # Add autoload section if it doesn't exist, then append the entry
+        _add_autoload_entry(project_godot, name, value)
+
+        data = {
+            "added": True,
+            "name": name,
+            "path": script_path,
+            "singleton": not no_singleton,
+        }
+
+        def _human(data: dict[str, Any], verbose: bool = False) -> None:
+            click.echo(
+                f"Registered autoload '{data['name']}' -> {data['path']}"
+                f"{' (singleton)' if data['singleton'] else ''}"
+            )
+
+        emit(data, _human, ctx)
+    except ProjectError as exc:
+        emit_error(exc, ctx)
+
+
+def _add_autoload_entry(
+    project_godot: Path, name: str, value: str
+) -> None:
+    """Append an autoload entry to project.godot, creating the section if needed."""
+    text = project_godot.read_text(encoding="utf-8")
+    lines = text.split("\n")
+
+    # Find [autoload] section
+    autoload_idx = None
+    for i, line in enumerate(lines):
+        if line.strip() == "[autoload]":
+            autoload_idx = i
+            break
+
+    entry_line = f"{name}={value}"
+
+    if autoload_idx is not None:
+        # Find the end of the autoload section (next section header or EOF)
+        insert_idx = autoload_idx + 1
+        while insert_idx < len(lines):
+            stripped = lines[insert_idx].strip()
+            if stripped.startswith("[") and stripped.endswith("]"):
+                break
+            insert_idx += 1
+        # Insert before the next section (or at EOF), after any trailing blank
+        lines.insert(insert_idx, entry_line)
+    else:
+        # Add [autoload] section at the end
+        if lines and lines[-1].strip() != "":
+            lines.append("")
+        lines.append("[autoload]")
+        lines.append("")
+        lines.append(entry_line)
+
+    project_godot.write_text("\n".join(lines), encoding="utf-8")

--- a/src/gdauto/commands/scene.py
+++ b/src/gdauto/commands/scene.py
@@ -116,10 +116,45 @@ def _print_dependencies(console: Console, scenes: list[dict[str, Any]]) -> None:
 )
 @click.pass_context
 def scene_create(ctx: click.Context, json_file: str, output: str | None) -> None:
-    """Create a Godot scene (.tscn) from a JSON definition file.
+    r"""Create a Godot scene (.tscn) from a JSON definition file.
 
-    The JSON file defines a node tree with types, properties, and optional
-    external resources. See 'gdauto scene create --help' for the JSON format.
+    \b
+    JSON FORMAT:
+      {
+        "root": {
+          "name": "Main",
+          "type": "Node2D",
+          "properties": {"position": "Vector2(100, 50)"},
+          "children": [
+            {"name": "Player", "type": "Sprite2D", "properties": {}}
+          ]
+        },
+        "resources": [
+          {
+            "type": "Texture2D",
+            "path": "res://sprite.png",
+            "assign_to": "Player",
+            "property": "texture"
+          }
+        ]
+      }
+
+    \b
+    FIELDS:
+      root.name       (required) Root node name
+      root.type       (required) Godot node type (Node2D, Control, etc.)
+      root.properties (optional) Key-value pairs of Godot properties
+      root.children   (optional) Array of child node objects (same schema)
+      resources       (optional) External resources to create and assign
+      resources[].type       Resource type (Texture2D, Script, etc.)
+      resources[].path       res:// path to the resource file
+      resources[].assign_to  Node name to assign the resource to
+      resources[].property   Property name on the target node
+
+    \b
+    NOTES:
+      - Script properties with res:// paths are auto-converted to ExtResource refs
+      - Property values use Godot syntax: Vector2(x,y), Color(r,g,b,a), etc.
     """
     json_path = Path(json_file)
     if not json_path.exists():
@@ -166,7 +201,7 @@ def scene_create(ctx: click.Context, json_file: str, output: str | None) -> None
 def _load_json(json_path: Path, ctx: click.Context) -> dict[str, Any] | None:
     """Load and parse a JSON file, emitting errors on failure."""
     try:
-        text = json_path.read_text()
+        text = json_path.read_text(encoding="utf-8")
         return json.loads(text)
     except json.JSONDecodeError as exc:
         emit_error(

--- a/src/gdauto/commands/sprite.py
+++ b/src/gdauto/commands/sprite.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import sys
 import warnings
 from pathlib import Path
 from typing import Any
@@ -146,15 +145,16 @@ def _do_import_aseprite(
         )
         return
 
-    image_res_path = _resolve_image_path(res_path, aseprite_data.meta.image)
-
-    # Warn if res:// path is filename-only (no subdirectory)
-    if res_path is None and "/" not in aseprite_data.meta.image:
+    # Explicit zero-frames check so the warning is always in structured output
+    if len(aseprite_data.frames) == 0:
         warnings_list.append(
-            f"Using flat res:// path '{image_res_path}' (no subdirectory). "
-            "Use --res-path to specify the correct Godot resource path "
-            "if the image is not at the project root."
+            "Aseprite JSON contains zero frames; the generated SpriteFrames "
+            "will have no animation data"
         )
+
+    image_res_path = _resolve_image_path(
+        res_path, aseprite_data.meta.image, output,
+    )
 
     result = _build_resource(aseprite_data, image_res_path, warnings_list, ctx)
     if result is None:
@@ -169,10 +169,25 @@ def _do_import_aseprite(
     )
 
 
-def _resolve_image_path(res_path: str | None, meta_image: str) -> str:
-    """Determine the Godot res:// path for the sprite sheet texture."""
+def _resolve_image_path(
+    res_path: str | None, meta_image: str, output: str | None
+) -> str:
+    """Determine the Godot res:// path for the sprite sheet texture.
+
+    Priority: explicit --res-path > inferred from -o directory > flat filename.
+    When -o is a relative path with subdirectories (e.g., sprites/char.tres),
+    the image path is inferred as res://<output_dir>/<image_filename> so agents
+    get correct paths by default. Absolute output paths are not used for
+    inference since they are not valid Godot res:// paths.
+    """
     if res_path is not None:
         return res_path
+    if output is not None:
+        output_path = Path(output)
+        if not output_path.is_absolute():
+            output_dir = output_path.parent
+            if str(output_dir) != ".":
+                return "res://" + (output_dir / Path(meta_image).name).as_posix()
     return "res://" + meta_image
 
 
@@ -646,18 +661,14 @@ def validate(ctx: click.Context, tres_file: str, godot: bool) -> None:
         )
         result = validate_spriteframes_headless(tres_path, backend)
 
-    if not result["valid"]:
-        # In JSON mode, write the full result to stderr for consistency
-        # with the error contract (exit code 1 -> stderr)
-        config = ctx.obj
-        if config and config.json_mode:
-            sys.stderr.write(json.dumps(result, indent=2) + "\n")
-        else:
-            _print_validate_result(result)
-        ctx.exit(1)
-        return
-
+    # Validate always writes to stdout (both valid and invalid results).
+    # This differs from error commands which write to stderr. The validate
+    # result is structured data, not an error, so consumers should always
+    # read stdout and check the "valid" key regardless of exit code.
     emit(result, _print_validate_result, ctx)
+
+    if not result["valid"]:
+        ctx.exit(1)
 
 
 def _print_validate_result(data: dict[str, Any], verbose: bool = False) -> None:

--- a/src/gdauto/commands/sprite.py
+++ b/src/gdauto/commands/sprite.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 import warnings
 from pathlib import Path
@@ -85,6 +86,26 @@ def import_aseprite(
       gdauto sprite import-aseprite character.json -o sprites/character.tres
       gdauto sprite import-aseprite character.json --res-path res://art/character.png
     """
+    try:
+        _do_import_aseprite(ctx, json_file, output, res_path)
+    except Exception as exc:
+        emit_error(
+            GdautoError(
+                message=f"Unexpected error: {exc}",
+                code="INTERNAL_ERROR",
+                fix="Report this issue with the full command and input file",
+            ),
+            ctx,
+        )
+
+
+def _do_import_aseprite(
+    ctx: click.Context,
+    json_file: str,
+    output: str | None,
+    res_path: str | None,
+) -> None:
+    """Inner implementation of import-aseprite, wrapped for error handling."""
     json_path = Path(json_file)
     if not json_path.exists():
         emit_error(
@@ -105,15 +126,14 @@ def import_aseprite(
             aseprite_data = parse_aseprite_json(json_path)
             for w in caught:
                 msg = str(w.message)
-                if "Skipping tag" in msg:
-                    warnings_list.append(msg)
-                    click.echo(msg, err=True)
+                warnings_list.append(msg)
+                click.echo(msg, err=True)
     except (ValidationError, GdautoError) as exc:
         emit_error(exc, ctx)
         return
 
     # If parser skipped tags and none remain, all tags failed (D-17)
-    had_skipped_tags = len(warnings_list) > 0
+    had_skipped_tags = any("Skipping tag" in w for w in warnings_list)
     no_valid_tags = len(aseprite_data.meta.frame_tags) == 0
     if had_skipped_tags and no_valid_tags:
         emit_error(
@@ -127,6 +147,15 @@ def import_aseprite(
         return
 
     image_res_path = _resolve_image_path(res_path, aseprite_data.meta.image)
+
+    # Warn if res:// path is filename-only (no subdirectory)
+    if res_path is None and "/" not in aseprite_data.meta.image:
+        warnings_list.append(
+            f"Using flat res:// path '{image_res_path}' (no subdirectory). "
+            "Use --res-path to specify the correct Godot resource path "
+            "if the image is not at the project root."
+        )
+
     result = _build_resource(aseprite_data, image_res_path, warnings_list, ctx)
     if result is None:
         return
@@ -281,6 +310,13 @@ def _emit_result(
     default=10.0,
     help="Animation FPS for the generated SpriteFrames. Default: 10.",
 )
+@click.option(
+    "--tags-from",
+    type=click.Path(exists=False),
+    default=None,
+    help="Aseprite JSON file to read frameTags from for animation names. "
+         "Auto-detected from adjacent .json file if not specified.",
+)
 @click.pass_context
 def split(
     ctx: click.Context,
@@ -290,6 +326,7 @@ def split(
     output: str | None,
     res_path: str | None,
     fps: float,
+    tags_from: str | None,
 ) -> None:
     """Split a sprite sheet into frames and generate a SpriteFrames .tres."""
     image_path = Path(image_file)
@@ -318,28 +355,70 @@ def split(
     output_path = Path(output) if output else image_path.with_suffix(".tres")
     image_res = res_path or f"res://{image_path.name}"
 
+    # Resolve tag source: explicit --tags-from, or auto-detect adjacent .json
+    tag_data = _resolve_tags(tags_from, image_path)
+
     try:
-        resource = _do_split(image_path, frame_size, json_meta, image_res, fps)
+        resource = _do_split(
+            image_path, frame_size, json_meta, image_res, fps, tag_data,
+        )
     except (GdautoError, ValidationError) as exc:
         emit_error(exc, ctx)
         return
 
     serialize_tres_file(resource, output_path)
 
+    anim_count = len(resource.resource_properties.get("animations", []))
+
     def _human(data: dict, verbose: bool = False) -> None:  # type: ignore[type-arg]
         click.echo(
-            f"Created {data['output']} with {data['frame_count']} frames"
+            f"Created {data['output']} with {data['animation_count']} "
+            f"animation(s) ({data['frame_count']} frames)"
         )
 
     emit(
         {
             "output": str(output_path),
             "frame_count": len(resource.sub_resources),
+            "animation_count": anim_count,
             "image": str(image_path),
         },
         _human,
         ctx,
     )
+
+
+def _resolve_tags(
+    tags_from: str | None, image_path: Path
+) -> list[dict[str, Any]] | None:
+    """Resolve animation tags from --tags-from or auto-detected adjacent JSON.
+
+    Returns a list of raw tag dicts (with name, from, to keys) or None
+    if no tag source is available.
+    """
+    tag_path: Path | None = None
+    if tags_from is not None:
+        tag_path = Path(tags_from)
+        if not tag_path.exists():
+            return None
+    else:
+        # Auto-detect adjacent .json file with same stem
+        candidate = image_path.with_suffix(".json")
+        if candidate.exists():
+            tag_path = candidate
+
+    if tag_path is None:
+        return None
+
+    try:
+        raw = json.loads(tag_path.read_text(encoding="utf-8"))
+        meta = raw.get("meta", {})
+        tags = meta.get("frameTags", [])
+        if tags:
+            return tags
+    except (json.JSONDecodeError, OSError):
+        pass
+    return None
 
 
 def _do_split(
@@ -348,14 +427,17 @@ def _do_split(
     json_meta: str | None,
     image_res: str,
     fps: float,
+    tag_data: list[dict[str, Any]] | None = None,
 ) -> GdResource:  # type: ignore[return]
     """Dispatch to grid or JSON splitting based on provided options."""
     from gdauto.sprite.splitter import split_sheet_grid, split_sheet_json
 
     if frame_size is not None:
         frame_w, frame_h = _parse_frame_size(frame_size)
-        return split_sheet_grid(image_path, frame_w, frame_h, image_res, fps)
-    if json_meta is not None:
+        resource = split_sheet_grid(
+            image_path, frame_w, frame_h, image_res, fps,
+        )
+    elif json_meta is not None:
         json_path = Path(json_meta)
         if not json_path.exists():
             raise GdautoError(
@@ -363,7 +445,54 @@ def _do_split(
                 code="FILE_NOT_FOUND",
                 fix="Check the JSON file path and try again",
             )
-        return split_sheet_json(image_path, json_path, image_res, fps)
+        resource = split_sheet_json(image_path, json_path, image_res, fps)
+    else:
+        return None  # type: ignore[return-value]
+
+    # Apply tag data to split animations by frame range
+    if tag_data and resource is not None:
+        _apply_tags_to_resource(resource, tag_data, fps)
+
+    return resource
+
+
+def _apply_tags_to_resource(
+    resource: GdResource,
+    tag_data: list[dict[str, Any]],
+    fps: float,
+) -> None:
+    """Replace the single 'default' animation with tagged animations.
+
+    Reads frameTags from Aseprite JSON and slices the sub_resources
+    into per-tag animation entries.
+    """
+    from gdauto.formats.values import StringName, SubResourceRef
+
+    subs = resource.sub_resources
+    animations: list[dict[str, Any]] = []
+
+    for tag in tag_data:
+        name = tag.get("name", "default")
+        from_idx = tag.get("from", 0)
+        to_idx = tag.get("to", len(subs) - 1)
+
+        # Clamp indices to available sub_resources
+        from_idx = max(0, min(from_idx, len(subs) - 1))
+        to_idx = max(from_idx, min(to_idx, len(subs) - 1))
+
+        frames = [
+            {"duration": 1.0, "texture": SubResourceRef(subs[i].id)}
+            for i in range(from_idx, to_idx + 1)
+        ]
+        animations.append({
+            "frames": frames,
+            "loop": True,
+            "name": StringName(name),
+            "speed": fps,
+        })
+
+    if animations:
+        resource.resource_properties["animations"] = animations
 
 
 def _parse_frame_size(frame_size: str) -> tuple[int, int]:
@@ -517,10 +646,18 @@ def validate(ctx: click.Context, tres_file: str, godot: bool) -> None:
         )
         result = validate_spriteframes_headless(tres_path, backend)
 
-    emit(result, _print_validate_result, ctx)
-
     if not result["valid"]:
+        # In JSON mode, write the full result to stderr for consistency
+        # with the error contract (exit code 1 -> stderr)
+        config = ctx.obj
+        if config and config.json_mode:
+            sys.stderr.write(json.dumps(result, indent=2) + "\n")
+        else:
+            _print_validate_result(result)
         ctx.exit(1)
+        return
+
+    emit(result, _print_validate_result, ctx)
 
 
 def _print_validate_result(data: dict[str, Any], verbose: bool = False) -> None:

--- a/src/gdauto/formats/aseprite.py
+++ b/src/gdauto/formats/aseprite.py
@@ -97,12 +97,6 @@ def parse_aseprite_json(path: Path) -> AsepriteData:
     raw = _load_json(path)
     _validate_has_frames(raw)
     frames = _parse_frames(raw["frames"])
-    if len(frames) == 0:
-        warnings.warn(
-            "Aseprite JSON contains zero frames; the generated SpriteFrames "
-            "will have no animation data. This is likely unintentional.",
-            stacklevel=2,
-        )
     meta = _parse_meta(raw.get("meta", {}))
     return AsepriteData(frames=frames, meta=meta)
 

--- a/src/gdauto/formats/aseprite.py
+++ b/src/gdauto/formats/aseprite.py
@@ -97,6 +97,12 @@ def parse_aseprite_json(path: Path) -> AsepriteData:
     raw = _load_json(path)
     _validate_has_frames(raw)
     frames = _parse_frames(raw["frames"])
+    if len(frames) == 0:
+        warnings.warn(
+            "Aseprite JSON contains zero frames; the generated SpriteFrames "
+            "will have no animation data. This is likely unintentional.",
+            stacklevel=2,
+        )
     meta = _parse_meta(raw.get("meta", {}))
     return AsepriteData(frames=frames, meta=meta)
 
@@ -104,12 +110,18 @@ def parse_aseprite_json(path: Path) -> AsepriteData:
 def _load_json(path: Path) -> dict:
     """Load and parse a JSON file, wrapping errors in ValidationError."""
     try:
-        return json.loads(path.read_text())
+        return json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
         raise ValidationError(
             message=f"Failed to parse JSON: {exc}",
             code="ASEPRITE_PARSE_ERROR",
             fix="Ensure the file is valid JSON exported by Aseprite",
+        ) from exc
+    except OSError as exc:
+        raise ValidationError(
+            message=f"Could not read file: {exc}",
+            code="FILE_READ_ERROR",
+            fix="Check that the file exists and is readable",
         ) from exc
 
 

--- a/src/gdauto/scene/builder.py
+++ b/src/gdauto/scene/builder.py
@@ -34,6 +34,9 @@ def build_scene(definition: dict[str, Any]) -> GdScene:
         ext_resources = _build_ext_resources(resources_defs)
         _assign_resources(nodes, resources_defs, ext_resources)
 
+    # Auto-create ExtResource entries for script properties (issue #9)
+    _promote_script_properties(nodes, ext_resources)
+
     uid = uid_to_text(generate_uid())
 
     return GdScene(
@@ -144,3 +147,27 @@ def _assign_resources(
         prop_name = res_def["property"]
         if target_name in node_map:
             node_map[target_name].properties[prop_name] = ExtResourceRef(ext.id)
+
+
+def _promote_script_properties(
+    nodes: list[SceneNode],
+    ext_resources: list[ExtResource],
+) -> None:
+    """Convert raw string script paths to proper ExtResource references.
+
+    When a node has a "script" property with a res:// string value,
+    creates an ExtResource of type "Script" and replaces the raw string
+    with an ExtResourceRef so Godot can load the script at runtime.
+    """
+    for node in nodes:
+        script_val = node.properties.get("script")
+        if not isinstance(script_val, str) or not script_val.startswith("res://"):
+            continue
+        ext = ExtResource(
+            type="Script",
+            path=script_val,
+            id=generate_resource_id("Script"),
+            uid=uid_to_text(generate_uid()),
+        )
+        ext_resources.append(ext)
+        node.properties["script"] = ExtResourceRef(ext.id)

--- a/src/gdauto/sprite/validator.py
+++ b/src/gdauto/sprite/validator.py
@@ -145,10 +145,13 @@ def _check_single_animation(
         issues.append(f"Animation '{name}' missing 'loop' key")
 
     frame_count = len(frames) if isinstance(frames, list) else 0
+    speed_val = speed if isinstance(speed, (int, float)) else 0
+    if isinstance(speed_val, float):
+        speed_val = round(speed_val, 2)
     summaries.append({
         "name": name,
         "frames": frame_count,
-        "speed": speed if isinstance(speed, (int, float)) else 0,
+        "speed": speed_val,
         "loop": bool(loop) if loop is not None else False,
     })
 

--- a/tests/unit/test_issue_fixes.py
+++ b/tests/unit/test_issue_fixes.py
@@ -1,0 +1,627 @@
+"""Tests for GitHub issue fixes (#1-#17).
+
+Each test class covers one or more issues to verify the fix works as expected.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from gdauto.cli import cli
+from gdauto.formats.values import ExtResourceRef
+from gdauto.scene.builder import build_scene
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures"
+FIXTURE_PROJECT = str(FIXTURES_DIR / "sample_project")
+FIXTURE_SIMPLE = str(FIXTURES_DIR / "aseprite_simple.json")
+
+
+# ---------------------------------------------------------------------------
+# Issue #9: scene create script property as ExtResource
+# ---------------------------------------------------------------------------
+
+
+class TestScriptPropertyPromotion:
+    """Verify that string script properties become ExtResource refs."""
+
+    def test_script_string_promoted_to_ext_resource_ref(self) -> None:
+        definition = {
+            "root": {
+                "name": "Main",
+                "type": "Node2D",
+                "properties": {"script": "res://scripts/main.gd"},
+            },
+        }
+        result = build_scene(definition)
+        assert isinstance(result.nodes[0].properties["script"], ExtResourceRef)
+
+    def test_script_promotion_creates_ext_resource(self) -> None:
+        definition = {
+            "root": {
+                "name": "Main",
+                "type": "Node2D",
+                "properties": {"script": "res://scripts/main.gd"},
+            },
+        }
+        result = build_scene(definition)
+        scripts = [e for e in result.ext_resources if e.type == "Script"]
+        assert len(scripts) == 1
+        assert scripts[0].path == "res://scripts/main.gd"
+
+    def test_script_promotion_on_child_node(self) -> None:
+        definition = {
+            "root": {
+                "name": "Root",
+                "type": "Node2D",
+                "children": [
+                    {
+                        "name": "Player",
+                        "type": "CharacterBody2D",
+                        "properties": {"script": "res://scripts/player.gd"},
+                    },
+                ],
+            },
+        }
+        result = build_scene(definition)
+        player = [n for n in result.nodes if n.name == "Player"][0]
+        assert isinstance(player.properties["script"], ExtResourceRef)
+
+    def test_non_res_script_not_promoted(self) -> None:
+        definition = {
+            "root": {
+                "name": "Root",
+                "type": "Node2D",
+                "properties": {"script": "some_local_path.gd"},
+            },
+        }
+        result = build_scene(definition)
+        # Non-res:// strings are not promoted
+        assert result.nodes[0].properties["script"] == "some_local_path.gd"
+
+
+# ---------------------------------------------------------------------------
+# Issue #12: project validate autoload scripts not orphaned
+# ---------------------------------------------------------------------------
+
+
+class TestAutoloadNotOrphan:
+    """Verify autoload-registered scripts are excluded from orphan list."""
+
+    def test_autoload_script_not_in_orphans(self, tmp_path: Path) -> None:
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / "project.godot").write_text(
+            '; config\n\nconfig_version=5\n\n'
+            '[application]\n\nconfig/name="Test"\n\n'
+            '[autoload]\n\nGameState="*res://scripts/game_state.gd"\n',
+            encoding="utf-8",
+        )
+        scripts_dir = project_dir / "scripts"
+        scripts_dir.mkdir()
+        (scripts_dir / "game_state.gd").write_text(
+            "extends Node\n", encoding="utf-8"
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["-j", "project", "validate", str(project_dir)]
+        )
+        data = json.loads(result.output)
+        assert "res://scripts/game_state.gd" not in data["orphan_scripts"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #14: sprite validate --json always writes to stdout
+# ---------------------------------------------------------------------------
+
+
+class TestSpriteValidateStdout:
+    """Verify validate always writes structured output to stdout."""
+
+    def test_valid_result_on_stdout(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["-j", "sprite", "validate", str(FIXTURES_DIR / "sample.tres")]
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["valid"] is True
+
+    def test_invalid_result_still_on_stdout(self, tmp_path: Path) -> None:
+        tres = tmp_path / "bad.tres"
+        tres.write_text(
+            '[gd_resource type="Theme" format=3]\n\n[resource]\n',
+            encoding="utf-8",
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["-j", "sprite", "validate", str(tres)]
+        )
+        assert result.exit_code == 1
+        # Output should be parseable JSON on stdout
+        data = json.loads(result.output)
+        assert data["valid"] is False
+
+
+# ---------------------------------------------------------------------------
+# Issue #1: godot_version in project info --json
+# ---------------------------------------------------------------------------
+
+
+class TestGodotVersionKey:
+    """Verify project info --json includes godot_version."""
+
+    def test_godot_version_present(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["-j", "project", "info", FIXTURE_PROJECT]
+        )
+        data = json.loads(result.output)
+        assert "godot_version" in data
+
+    def test_godot_version_value(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["-j", "project", "info", FIXTURE_PROJECT]
+        )
+        data = json.loads(result.output)
+        assert data["godot_version"] == "4.5"
+
+
+# ---------------------------------------------------------------------------
+# Issue #2: validate checks project.godot resource references
+# ---------------------------------------------------------------------------
+
+
+class TestProjectGodotRefValidation:
+    """Verify validate checks main_scene and icon in project.godot."""
+
+    def test_missing_main_scene_detected(self, tmp_path: Path) -> None:
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / "project.godot").write_text(
+            '; config\n\nconfig_version=5\n\n'
+            '[application]\n\n'
+            'config/name="Test"\n'
+            'run/main_scene="res://scenes/missing.tscn"\n'
+            'config/icon="res://icon.svg"\n',
+            encoding="utf-8",
+        )
+        (project_dir / "icon.svg").write_text("<svg/>", encoding="utf-8")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["-j", "project", "validate", str(project_dir)]
+        )
+        data = json.loads(result.output)
+        assert "res://scenes/missing.tscn" in data["missing_resources"]
+
+    def test_files_scanned_includes_project_godot(self, tmp_path: Path) -> None:
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / "project.godot").write_text(
+            '; config\n\nconfig_version=5\n\n'
+            '[application]\n\nconfig/name="Test"\n',
+            encoding="utf-8",
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["-j", "project", "validate", str(project_dir)]
+        )
+        data = json.loads(result.output)
+        # project.godot counts as +1
+        assert data["files_scanned"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #4: res:// path inference from -o
+# ---------------------------------------------------------------------------
+
+
+class TestResPathInference:
+    """Verify --res-path is auto-inferred from -o directory."""
+
+    def test_relative_output_subdir_infers_res_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        src = tmp_path / "input.json"
+        src.write_text(Path(FIXTURE_SIMPLE).read_text(), encoding="utf-8")
+        # Create the output subdirectory
+        out_dir = tmp_path / "sprites" / "aseprite"
+        out_dir.mkdir(parents=True)
+
+        # cd into tmp_path so the relative -o resolves correctly
+        monkeypatch.chdir(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "-j", "sprite", "import-aseprite", str(src),
+                "-o", "sprites/aseprite/output.tres",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        # Should infer res://sprites/aseprite/simple_sheet.png
+        assert data["image_path"] == "res://sprites/aseprite/simple_sheet.png"
+
+    def test_absolute_output_uses_flat_path(self, tmp_path: Path) -> None:
+        """Absolute -o paths can't be converted to res://, so use flat."""
+        src = tmp_path / "input.json"
+        src.write_text(Path(FIXTURE_SIMPLE).read_text(), encoding="utf-8")
+        output = tmp_path / "output.tres"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["-j", "sprite", "import-aseprite", str(src), "-o", str(output)],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        # Absolute path, so flat fallback
+        assert data["image_path"] == "res://simple_sheet.png"
+
+    def test_no_output_uses_flat_path(self, tmp_path: Path) -> None:
+        src = tmp_path / "input.json"
+        src.write_text(Path(FIXTURE_SIMPLE).read_text(), encoding="utf-8")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["-j", "sprite", "import-aseprite", str(src)],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        # No -o, so flat path
+        assert data["image_path"] == "res://simple_sheet.png"
+
+
+# ---------------------------------------------------------------------------
+# Issue #6: speed field rounding in sprite validate
+# ---------------------------------------------------------------------------
+
+
+class TestSpeedRounding:
+    """Verify speed values are rounded to 2 decimal places."""
+
+    def test_speed_rounded(self) -> None:
+        from gdauto.sprite.validator import validate_spriteframes
+
+        result = validate_spriteframes(FIXTURES_DIR / "sample.tres")
+        for anim in result["animations"]:
+            speed = anim["speed"]
+            if isinstance(speed, float):
+                assert speed == round(speed, 2)
+
+
+# ---------------------------------------------------------------------------
+# Issue #10: project add-autoload command
+# ---------------------------------------------------------------------------
+
+
+class TestProjectAddAutoload:
+    """Verify add-autoload registers singletons in project.godot."""
+
+    def test_add_autoload_creates_entry(self, tmp_path: Path) -> None:
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / "project.godot").write_text(
+            '; config\n\nconfig_version=5\n\n'
+            '[application]\n\nconfig/name="Test"\n',
+            encoding="utf-8",
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "project", "add-autoload",
+                "--name", "GameState",
+                "--path", "res://scripts/game_state.gd",
+                str(project_dir),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        content = (project_dir / "project.godot").read_text()
+        assert "[autoload]" in content
+        assert "GameState" in content
+        assert "res://scripts/game_state.gd" in content
+
+    def test_add_autoload_json_output(self, tmp_path: Path) -> None:
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / "project.godot").write_text(
+            '; config\n\nconfig_version=5\n\n'
+            '[application]\n\nconfig/name="Test"\n',
+            encoding="utf-8",
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "-j", "project", "add-autoload",
+                "--name", "GameState",
+                "--path", "res://scripts/game_state.gd",
+                str(project_dir),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["added"] is True
+        assert data["name"] == "GameState"
+        assert data["singleton"] is True
+
+    def test_add_autoload_duplicate_fails(self, tmp_path: Path) -> None:
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / "project.godot").write_text(
+            '; config\n\nconfig_version=5\n\n'
+            '[application]\n\nconfig/name="Test"\n\n'
+            '[autoload]\n\nGameState="*res://scripts/game_state.gd"\n',
+            encoding="utf-8",
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "project", "add-autoload",
+                "--name", "GameState",
+                "--path", "res://scripts/other.gd",
+                str(project_dir),
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_add_autoload_no_singleton(self, tmp_path: Path) -> None:
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / "project.godot").write_text(
+            '; config\n\nconfig_version=5\n\n'
+            '[application]\n\nconfig/name="Test"\n',
+            encoding="utf-8",
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "-j", "project", "add-autoload",
+                "--name", "Utils",
+                "--path", "res://scripts/utils.gd",
+                "--no-singleton",
+                str(project_dir),
+            ],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["singleton"] is False
+        content = (project_dir / "project.godot").read_text()
+        # No * prefix
+        assert '"res://scripts/utils.gd"' in content
+
+
+# ---------------------------------------------------------------------------
+# Issue #11: autoloads strip * prefix in project info
+# ---------------------------------------------------------------------------
+
+
+class TestAutoloadStripPrefix:
+    """Verify project info --json strips * from autoload paths."""
+
+    def test_autoload_path_no_star(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["-j", "project", "info", FIXTURE_PROJECT]
+        )
+        data = json.loads(result.output)
+        for _name, path in data["autoloads"].items():
+            assert not path.startswith("*"), f"Path still has * prefix: {path}"
+            assert path.startswith("res://")
+
+
+# ---------------------------------------------------------------------------
+# Issue #17: empty frames warning in structured output
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyFramesWarning:
+    """Verify empty frames produce a warning in the JSON output."""
+
+    def test_empty_frames_json_has_warning(self, tmp_path: Path) -> None:
+        empty_json = tmp_path / "empty.json"
+        empty_json.write_text(
+            json.dumps({
+                "frames": [],
+                "meta": {
+                    "app": "test",
+                    "version": "1.0",
+                    "image": "empty.png",
+                    "format": "RGBA8888",
+                    "size": {"w": 0, "h": 0},
+                    "scale": "1",
+                    "frameTags": [],
+                    "slices": [],
+                },
+            }),
+            encoding="utf-8",
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["-j", "sprite", "import-aseprite", str(empty_json)],
+        )
+        # Should either produce a warning in output or error
+        # The important thing: no silent success with 0 frames
+        output_text = result.output
+        if result.exit_code == 0:
+            data = json.loads(output_text)
+            assert any("zero frames" in w.lower() for w in data.get("warnings", []))
+
+
+# ---------------------------------------------------------------------------
+# Issue #3: --check-only diagnostic key
+# ---------------------------------------------------------------------------
+
+
+class TestCheckOnlyDiagnostic:
+    """Verify --check-only adds diagnostic keys when skipped."""
+
+    def test_no_scripts_adds_skip_key(self, tmp_path: Path) -> None:
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / "project.godot").write_text(
+            '; config\n\nconfig_version=5\n\n'
+            '[application]\n\nconfig/name="Test"\n',
+            encoding="utf-8",
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["-j", "project", "validate", "--check-only", str(project_dir)],
+        )
+        data = json.loads(result.output)
+        assert data.get("godot_check_skipped") is True
+        assert "no .gd scripts" in data.get("godot_check_skip_reason", "")
+
+
+# ---------------------------------------------------------------------------
+# Issue #8: scene create --help has actual schema
+# ---------------------------------------------------------------------------
+
+
+class TestSceneCreateHelp:
+    """Verify scene create --help shows JSON format, not circular reference."""
+
+    def test_help_shows_json_format(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["scene", "create", "--help"])
+        assert "JSON FORMAT:" in result.output
+        assert "root.name" in result.output
+        assert "root.type" in result.output
+
+    def test_help_no_circular_reference(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["scene", "create", "--help"])
+        assert "See 'gdauto scene create --help'" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Issue #5: sprite split --tags-from
+# ---------------------------------------------------------------------------
+
+
+class TestSplitTagsFrom:
+    """Verify sprite split reads frameTags when --tags-from is provided."""
+
+    def test_tags_from_produces_named_animations(self, tmp_path: Path) -> None:
+        """Create a minimal sprite sheet image and JSON with tags."""
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("Pillow not installed")
+
+        # Create a 64x32 test image (2 frames of 32x32)
+        img = Image.new("RGBA", (64, 32), (255, 0, 0, 255))
+        img_path = tmp_path / "sheet.png"
+        img.save(img_path)
+
+        # Create Aseprite JSON with frameTags
+        tag_json = tmp_path / "sheet.json"
+        tag_json.write_text(
+            json.dumps({
+                "frames": [
+                    {
+                        "filename": "0",
+                        "frame": {"x": 0, "y": 0, "w": 32, "h": 32},
+                        "rotated": False,
+                        "trimmed": False,
+                        "spriteSourceSize": {"x": 0, "y": 0, "w": 32, "h": 32},
+                        "sourceSize": {"w": 32, "h": 32},
+                        "duration": 100,
+                    },
+                    {
+                        "filename": "1",
+                        "frame": {"x": 32, "y": 0, "w": 32, "h": 32},
+                        "rotated": False,
+                        "trimmed": False,
+                        "spriteSourceSize": {"x": 0, "y": 0, "w": 32, "h": 32},
+                        "sourceSize": {"w": 32, "h": 32},
+                        "duration": 100,
+                    },
+                ],
+                "meta": {
+                    "app": "test",
+                    "version": "1.0",
+                    "image": "sheet.png",
+                    "format": "RGBA8888",
+                    "size": {"w": 64, "h": 32},
+                    "scale": "1",
+                    "frameTags": [
+                        {"name": "walk", "from": 0, "to": 0, "direction": "forward"},
+                        {"name": "run", "from": 1, "to": 1, "direction": "forward"},
+                    ],
+                    "slices": [],
+                },
+            }),
+            encoding="utf-8",
+        )
+
+        output = tmp_path / "output.tres"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "-j", "sprite", "split", str(img_path),
+                "--frame-size", "32x32",
+                "--tags-from", str(tag_json),
+                "-o", str(output),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["animation_count"] == 2
+
+        content = output.read_text()
+        assert '&"walk"' in content
+        assert '&"run"' in content
+
+    def test_auto_detect_adjacent_json(self, tmp_path: Path) -> None:
+        """Tags auto-detected from adjacent .json with same stem."""
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("Pillow not installed")
+
+        img = Image.new("RGBA", (32, 32), (255, 0, 0, 255))
+        img_path = tmp_path / "sprite.png"
+        img.save(img_path)
+
+        # Adjacent JSON with same stem
+        tag_json = tmp_path / "sprite.json"
+        tag_json.write_text(
+            json.dumps({
+                "frames": [],
+                "meta": {
+                    "frameTags": [
+                        {"name": "idle", "from": 0, "to": 0, "direction": "forward"},
+                    ],
+                },
+            }),
+            encoding="utf-8",
+        )
+
+        output = tmp_path / "output.tres"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "-j", "sprite", "split", str(img_path),
+                "--frame-size", "32x32",
+                "-o", str(output),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["animation_count"] == 1
+        content = output.read_text()
+        assert '&"idle"' in content


### PR DESCRIPTION
## Summary

Resolves all 16 open GitHub issues (#1 through #17, no #7) in a single pass. All 694 tests pass (668 existing + 26 new).

### Bugs Fixed (5)
- **#9** `scene create`: script properties now auto-create ExtResource refs instead of raw strings
- **#12** `project validate`: autoload-registered scripts no longer reported as orphans
- **#14** `sprite validate --json`: output contract preserved (always stdout); documented that validate writes structured results to stdout regardless of validity
- **#15** `sprite import-aseprite`: CJK filenames no longer crash (explicit UTF-8 encoding)
- **#16** `sprite import-aseprite`: emoji filenames no longer produce raw tracebacks (top-level exception handler)

### Enhancements (8)
- **#1** `project info --json`: new `godot_version` key extracted from features PackedStringArray
- **#2** `project validate`: now checks main_scene, icon, and autoload paths in project.godot
- **#4** `sprite import-aseprite`: auto-infers `res://` path from relative `-o` directory (e.g., `-o sprites/char.tres` produces `res://sprites/sheet.png`)
- **#5** `sprite split`: new `--tags-from` flag + auto-detects adjacent JSON for animation names
- **#6** `sprite validate --json`: speed field rounded to 2 decimal places
- **#10** New `project add-autoload` command with `--name`, `--path`, `--no-singleton`
- **#11** `project info --json`: autoload values no longer retain `*` singleton prefix
- **#17** `sprite import-aseprite`: warns on empty frames array (0 frames) in the structured JSON `warnings` field

### Documentation (3)
- **#3** `project validate --check-only`: adds `godot_check_skipped` diagnostic key + stderr warning
- **#8** `scene create --help`: replaces circular self-reference with full JSON schema docs
- **#13** CLAUDE.md and README.md updated to document actual `{error, code, fix}` fields

### Review feedback addressed
1. **#4**: Changed from warning-only to auto-inference from relative `-o` path (absolute paths fall back to flat filename)
2. **#17**: Zero-frames warning now added directly to `warnings_list` at the command level so it always appears in `--json` structured output
3. **#14**: Reverted the breaking stdout/stderr change; validate always writes to stdout with documented contract
4. UID determinism noted as out of scope (no filed issue)
5. **Added 26 new tests** covering all new behaviors

## Test plan
- [x] All 694 unit tests pass (668 existing + 26 new)
- [x] Verify `scene create` with script property generates ExtResource block (4 tests)
- [x] Verify `project validate` no longer reports autoload scripts as orphans (1 test)
- [x] Verify `sprite validate --json` keeps output on stdout for both valid/invalid (2 tests)
- [x] Verify `project info --json` includes `godot_version` and clean autoload paths (3 tests)
- [x] Verify `project add-autoload` registers singletons in project.godot (4 tests)
- [x] Verify `sprite split --tags-from` produces named animations (2 tests)
- [x] Verify `scene create --help` shows JSON schema (2 tests)
- [x] Verify `--check-only` adds diagnostic keys when skipped (1 test)
- [x] Verify empty frames produces structured warning (1 test)
- [x] Verify res-path inference from -o works for relative paths (3 tests)
- [x] Verify speed rounding in validate output (1 test)

Closes #1, #2, #3, #4, #5, #6, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)