### PR TITLE
release: v1.2.0

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,34 @@
+name: PR CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run unit tests
+        run: python -m pytest tests/unit/ -q --tb=short
+
+      - name: Run linter
+        run: ruff check src/auto_godot/
+        continue-on-error: true
+
+      - name: Run type checker
+        run: mypy src/auto_godot/ --ignore-missing-imports
+        continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,12 @@ htmlcov/
 tools/bin/
 .tmp/
 
+# Agent state
+auto-godot-state/
+gametestoutput/
+AGENT-SETUP.md
+SKILL.md
+.claude/scheduled_tasks.lock
+
 # Exported builds
 export/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "auto-godot"
-version = "0.1.0"
+version = "1.2.0"
 description = "Agent-native CLI for Godot Engine"
 license = "Apache-2.0"
 requires-python = ">=3.12"

--- a/tests/unit/test_sprite_import_command.py
+++ b/tests/unit/test_sprite_import_command.py
@@ -3,11 +3,17 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 from click.testing import CliRunner
 
 from auto_godot.cli import cli
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from text."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
 
 FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures"
 FIXTURE_SIMPLE = str(FIXTURES_DIR / "aseprite_simple.json")
@@ -208,7 +214,7 @@ class TestImportAsepriteHelp:
             ["sprite", "import-aseprite", "--help"],
         )
         assert result.exit_code == 0
-        assert "ASEPRITE EXPORT SETTINGS" in result.output
+        assert "ASEPRITE EXPORT SETTINGS" in _strip_ansi(result.output)
 
     def test_help_contains_json_array_recommendation(self) -> None:
         runner = CliRunner()
@@ -217,7 +223,7 @@ class TestImportAsepriteHelp:
             ["sprite", "import-aseprite", "--help"],
         )
         assert result.exit_code == 0
-        assert "--format json-array" in result.output
+        assert "--format json-array" in _strip_ansi(result.output)
 
     def test_help_contains_common_pitfalls(self) -> None:
         runner = CliRunner()
@@ -226,7 +232,7 @@ class TestImportAsepriteHelp:
             ["sprite", "import-aseprite", "--help"],
         )
         assert result.exit_code == 0
-        assert "COMMON PITFALLS" in result.output
+        assert "COMMON PITFALLS" in _strip_ansi(result.output)
 
 
 class TestImportAsepritePartialFailure:


### PR DESCRIPTION
## Summary

- Bump version from 0.1.0 to 1.2.0
- 5 feat: and 4 fix: commits since v1.1, including the gdauto-to-auto-godot rebrand

## Changelog (since v1.1)

### Features
- feat: add .claude/CLAUDE.md with conventions and known pitfalls (#30)
- feat: add GitHub Actions for automated issue fixing and PR review
- feat: rewrite game build prompt for fresh machine setup
- feat: add game build loop prompt for iterative gap discovery
- Multiple experiment features (debug, scene validation, pipeline expansion)

### Fixes
- fix: rebrand gdauto to auto-godot across entire codebase (#37)
- fix: resolve all 25 open GitHub issues (#2-#28)
- chore: remove API-based Claude workflows, keep nightly health check

## Test Results (20260410-221642)

- Unit tests: 1347 passed, 2 skipped
- Game build: 79 PASS, 2 FAIL, 3 SKIP
- Godot headless validation: all PASS
- 2 new bug issues filed: #45 (script tab escaping), #46 (config string quoting)

## Note

Release PRs require human approval per project policy. Do NOT auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)