### PR TITLE
fix: replace literal \t with real tabs in script add-method body

### DIFF
--- a/src/auto_godot/commands/script.py
+++ b/src/auto_godot/commands/script.py
@@ -488,7 +488,7 @@ def add_method(
             "",
             f"func {method_name}({param_str}) -> {return_type}:",
         ]
-        for body_line in body.replace("\\n", "\n").split("\n"):
+        for body_line in body.replace("\\n", "\n").replace("\\t", "\t").split("\n"):
             method_lines.append(f"\t{body_line}")
 
         insert_idx = _find_insert_point(lines, "method")


### PR DESCRIPTION
## Summary

- `script add-method --body` now replaces literal `\t` with real tab characters
- Fixes nested indentation in generated GDScript (e.g., `if true:\n\tprint(...)`)

## Root cause

The `--body` parameter passes through the shell, so `\t` arrives as two literal characters. The code already handled `\n` -> newline but not `\t` -> tab.

## Test plan

- [x] Unit tests pass (1349 passed)
- [x] Manual test: `auto-godot script add-method --body 'if true:\n\tprint("x")'` produces properly indented GDScript

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)