### PR TITLE
feat: add list-inputs and remove-input commands

### DIFF
--- a/src/auto_godot/commands/project.py
+++ b/src/auto_godot/commands/project.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 from typing import Any
 
@@ -12,7 +13,12 @@ from rich.table import Table
 
 from auto_godot.backend import GodotBackend
 from auto_godot.errors import GodotBinaryError, ProjectError
-from auto_godot.formats.project_cfg import parse_project_config, serialize_project_config
+from auto_godot.formats.project_cfg import (
+    _bracket_depth,
+    parse_project_config,
+    serialize_project_config,
+)
+
 from auto_godot.formats.tscn import parse_tscn_file
 from auto_godot.formats.tres import parse_tres_file
 from auto_godot.output import GlobalConfig, emit, emit_error
@@ -1175,6 +1181,247 @@ def add_input(
                 f"Added input action '{data['action']}' "
                 f"with {data['event_count']} binding(s): {', '.join(bindings)}"
             )
+
+        emit(data, _human, ctx)
+    except ProjectError as exc:
+        emit_error(exc, ctx)
+
+
+# ---------------------------------------------------------------------------
+# Reverse lookup tables for human-friendly input binding display
+# ---------------------------------------------------------------------------
+
+# Build reverse maps from keycode/button index to human name
+_REVERSE_KEY_CODES: dict[int, str] = {v: k for k, v in _KEY_CODES.items()}
+_REVERSE_MOUSE_BUTTONS: dict[int, str] = {v: k for k, v in _MOUSE_BUTTONS.items()}
+_REVERSE_JOY_BUTTONS: dict[int, str] = {v: k for k, v in _JOY_BUTTONS.items()}
+
+
+def _parse_input_bindings(
+    value: str,
+) -> list[dict[str, str]]:
+    """Extract binding info from a Godot input action value string.
+
+    Parses the Object() entries within the events array to identify
+    the event type and the relevant key/button value. Returns a list
+    of dicts with 'type' and 'value' keys.
+    """
+    bindings: list[dict[str, str]] = []
+
+    # Find all Object(...) entries in the value
+    for match in re.finditer(r'Object\((\w+),', value):
+        event_type = match.group(1)
+        # Extract the substring for this Object() entry
+        start = match.start()
+        # Find the matching closing paren, respecting nesting
+        depth = 0
+        end = start
+        for i in range(start, len(value)):
+            if value[i] == '(':
+                depth += 1
+            elif value[i] == ')':
+                depth -= 1
+                if depth == 0:
+                    end = i + 1
+                    break
+        obj_str = value[start:end]
+
+        if event_type == "InputEventKey":
+            code_match = re.search(r'"physical_keycode":(\d+)', obj_str)
+            if code_match:
+                code = int(code_match.group(1))
+                name = _REVERSE_KEY_CODES.get(code, str(code))
+                bindings.append({"type": "key", "value": name})
+        elif event_type == "InputEventMouseButton":
+            btn_match = re.search(r'"button_index":(\d+)', obj_str)
+            if btn_match:
+                idx = int(btn_match.group(1))
+                name = _REVERSE_MOUSE_BUTTONS.get(idx, str(idx))
+                bindings.append({"type": "mouse", "value": name})
+        elif event_type == "InputEventJoypadButton":
+            btn_match = re.search(r'"button_index":(\d+)', obj_str)
+            if btn_match:
+                idx = int(btn_match.group(1))
+                name = _REVERSE_JOY_BUTTONS.get(idx, str(idx))
+                bindings.append({"type": "joypad", "value": name})
+
+    return bindings
+
+
+# ---------------------------------------------------------------------------
+# project list-inputs
+# ---------------------------------------------------------------------------
+
+
+@project.command("list-inputs")
+@click.argument("project_path", default=".", type=click.Path())
+@click.pass_context
+def list_inputs(
+    ctx: click.Context,
+    project_path: str,
+) -> None:
+    """List all input actions defined in project.godot.
+
+    Reads the [input] section and displays each action with its bindings.
+
+    Examples:
+
+      auto-godot project list-inputs
+
+      auto-godot --json project list-inputs ./my-game
+    """
+    try:
+        project_godot = _find_project_godot(project_path)
+        config_text = project_godot.read_text(encoding="utf-8")
+        cfg = parse_project_config(config_text)
+
+        input_section = cfg.sections.get("input", [])
+        actions: list[dict[str, Any]] = []
+        for action_name, raw_value in input_section:
+            bindings = _parse_input_bindings(raw_value)
+            actions.append({
+                "action": action_name,
+                "bindings": bindings,
+            })
+
+        data = {"actions": actions, "count": len(actions)}
+
+        def _human(data: dict[str, Any], verbose: bool = False) -> None:
+            if not data["actions"]:
+                click.echo("No input actions defined.")
+                return
+            for entry in data["actions"]:
+                binding_parts: list[str] = []
+                keys = [b["value"] for b in entry["bindings"] if b["type"] == "key"]
+                mouse = [b["value"] for b in entry["bindings"] if b["type"] == "mouse"]
+                joypad = [b["value"] for b in entry["bindings"] if b["type"] == "joypad"]
+                if keys:
+                    binding_parts.append(f"keys: {', '.join(keys)}")
+                if mouse:
+                    binding_parts.append(f"mouse: {', '.join(mouse)}")
+                if joypad:
+                    binding_parts.append(f"joypad: {', '.join(joypad)}")
+                summary = "; ".join(binding_parts) if binding_parts else "no bindings"
+                click.echo(f"{entry['action']} ({summary})")
+
+        emit(data, _human, ctx)
+    except ProjectError as exc:
+        emit_error(exc, ctx)
+
+
+# ---------------------------------------------------------------------------
+# project remove-input
+# ---------------------------------------------------------------------------
+
+
+def _remove_section_entry(
+    project_godot: Path, section: str, key: str,
+) -> None:
+    """Remove a key and its (possibly multi-line) value from a section.
+
+    Reads project.godot line by line, skips the target key's lines
+    (including continuation lines for multi-line values with unbalanced
+    brackets), and writes the result back.
+    """
+    text = project_godot.read_text(encoding="utf-8")
+    lines = text.split("\n")
+
+    section_idx: int | None = None
+    for i, line in enumerate(lines):
+        if line.strip() == f"[{section}]":
+            section_idx = i
+            break
+
+    if section_idx is None:
+        raise ProjectError(
+            message=f"Section [{section}] not found in project.godot",
+            code="SECTION_NOT_FOUND",
+            fix=f"Ensure [{section}] exists in project.godot",
+        )
+
+    # Find the key within the section
+    key_start: int | None = None
+    key_end: int | None = None
+    i = section_idx + 1
+    while i < len(lines):
+        stripped = lines[i].strip()
+        # Stop if we hit the next section
+        if stripped.startswith("[") and stripped.endswith("]"):
+            break
+        if stripped.startswith(f"{key}="):
+            key_start = i
+            # Check if value spans multiple lines (unbalanced brackets)
+            value_part = stripped[len(key) + 1:]
+            depth = _bracket_depth(value_part)
+            key_end = i + 1
+            while depth > 0 and key_end < len(lines):
+                depth += _bracket_depth(lines[key_end])
+                key_end += 1
+            break
+        i += 1
+
+    if key_start is None:
+        raise ProjectError(
+            message=f"Input action '{key}' not found in [{section}]",
+            code="INPUT_NOT_FOUND",
+            fix="Use 'auto-godot project list-inputs' to see existing actions",
+        )
+
+    # Remove the key lines
+    del lines[key_start:key_end]
+
+    project_godot.write_text("\n".join(lines), encoding="utf-8")
+
+
+@project.command("remove-input")
+@click.option(
+    "--action", required=True,
+    help="Input action name to remove (e.g., move_up, jump)",
+)
+@click.argument("project_path", default=".", type=click.Path())
+@click.pass_context
+def remove_input(
+    ctx: click.Context,
+    action: str,
+    project_path: str,
+) -> None:
+    """Remove an input action from project.godot.
+
+    Deletes the specified action and all its bindings from the [input]
+    section.
+
+    Examples:
+
+      auto-godot project remove-input --action jump
+
+      auto-godot project remove-input --action move_up ./my-game
+    """
+    try:
+        project_godot = _find_project_godot(project_path)
+        config_text = project_godot.read_text(encoding="utf-8")
+        cfg = parse_project_config(config_text)
+
+        # Verify the action exists before attempting removal
+        input_section = cfg.sections.get("input", [])
+        found = False
+        for key, _val in input_section:
+            if key == action:
+                found = True
+                break
+
+        if not found:
+            raise ProjectError(
+                message=f"Input action '{action}' not found",
+                code="INPUT_NOT_FOUND",
+                fix="Use 'auto-godot project list-inputs' to see existing actions",
+            )
+
+        _remove_section_entry(project_godot, "input", action)
+
+        data = {"removed": True, "action": action}
+
+        def _human(data: dict[str, Any], verbose: bool = False) -> None:
+            click.echo(f"Removed input action '{data['action']}'")
 
         emit(data, _human, ctx)
     except ProjectError as exc:

--- a/tests/unit/test_input_commands.py
+++ b/tests/unit/test_input_commands.py
@@ -315,3 +315,248 @@ class TestAddInputKeyNames:
                 str(tmp_path),
             ])
             assert result.exit_code == 0, f"Failed for key 'f{i}': {result.output}"
+
+
+# ---------------------------------------------------------------------------
+# Tests for project list-inputs
+# ---------------------------------------------------------------------------
+
+
+def _make_project_with_inputs(tmp_path: Path) -> Path:
+    """Create a project.godot with pre-existing input actions."""
+    project_godot = tmp_path / "project.godot"
+    runner = CliRunner()
+    project_godot.write_text(
+        'config_version=5\n'
+        '\n'
+        '[application]\n'
+        '\n'
+        'config/name="TestGame"\n',
+        encoding="utf-8",
+    )
+    runner.invoke(cli, [
+        "project", "add-input",
+        "--action", "move_up", "--key", "w", "--key", "up",
+        str(tmp_path),
+    ])
+    runner.invoke(cli, [
+        "project", "add-input",
+        "--action", "jump", "--key", "space", "--joypad", "a",
+        str(tmp_path),
+    ])
+    return project_godot
+
+
+class TestListInputsBasic:
+    """Verify list-inputs shows input actions."""
+
+    def test_list_empty(self, tmp_path: Path) -> None:
+        _make_project(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "project", "list-inputs", str(tmp_path),
+        ])
+        assert result.exit_code == 0
+        assert "No input actions defined" in result.output
+
+    def test_list_with_actions(self, tmp_path: Path) -> None:
+        _make_project_with_inputs(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "project", "list-inputs", str(tmp_path),
+        ])
+        assert result.exit_code == 0
+        assert "move_up" in result.output
+        assert "jump" in result.output
+
+    def test_list_shows_key_names(self, tmp_path: Path) -> None:
+        _make_project_with_inputs(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "project", "list-inputs", str(tmp_path),
+        ])
+        assert result.exit_code == 0
+        # move_up is bound to w and up
+        assert "w" in result.output
+        assert "up" in result.output
+
+    def test_list_shows_joypad(self, tmp_path: Path) -> None:
+        _make_project_with_inputs(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "project", "list-inputs", str(tmp_path),
+        ])
+        assert result.exit_code == 0
+        assert "joypad" in result.output
+
+    def test_list_no_project_error(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "project", "list-inputs", "/nonexistent/path",
+        ])
+        assert result.exit_code != 0
+
+
+class TestListInputsJson:
+    """Verify JSON output for list-inputs."""
+
+    def test_json_empty(self, tmp_path: Path) -> None:
+        _make_project(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "-j", "project", "list-inputs", str(tmp_path),
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["actions"] == []
+        assert data["count"] == 0
+
+    def test_json_with_actions(self, tmp_path: Path) -> None:
+        _make_project_with_inputs(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "-j", "project", "list-inputs", str(tmp_path),
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["count"] == 2
+        actions = {a["action"]: a for a in data["actions"]}
+        assert "move_up" in actions
+        assert "jump" in actions
+
+    def test_json_binding_structure(self, tmp_path: Path) -> None:
+        _make_project_with_inputs(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "-j", "project", "list-inputs", str(tmp_path),
+        ])
+        data = json.loads(result.output)
+        actions = {a["action"]: a for a in data["actions"]}
+        # move_up has two key bindings (w, up)
+        move_up_bindings = actions["move_up"]["bindings"]
+        assert len(move_up_bindings) == 2
+        assert all(b["type"] == "key" for b in move_up_bindings)
+        # jump has one key + one joypad
+        jump_bindings = actions["jump"]["bindings"]
+        assert len(jump_bindings) == 2
+        types = {b["type"] for b in jump_bindings}
+        assert "key" in types
+        assert "joypad" in types
+
+
+# ---------------------------------------------------------------------------
+# Tests for project remove-input
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveInputBasic:
+    """Verify remove-input deletes input actions."""
+
+    def test_remove_action(self, tmp_path: Path) -> None:
+        _make_project_with_inputs(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "project", "remove-input",
+            "--action", "jump",
+            str(tmp_path),
+        ])
+        assert result.exit_code == 0, result.output
+        assert "Removed" in result.output
+        text = (tmp_path / "project.godot").read_text()
+        assert "jump=" not in text
+        # move_up should still be there
+        assert "move_up=" in text
+
+    def test_remove_first_action(self, tmp_path: Path) -> None:
+        _make_project_with_inputs(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "project", "remove-input",
+            "--action", "move_up",
+            str(tmp_path),
+        ])
+        assert result.exit_code == 0, result.output
+        text = (tmp_path / "project.godot").read_text()
+        assert "move_up=" not in text
+        assert "jump=" in text
+
+    def test_remove_nonexistent_error(self, tmp_path: Path) -> None:
+        _make_project(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "project", "remove-input",
+            "--action", "nonexistent",
+            str(tmp_path),
+        ])
+        assert result.exit_code != 0
+
+    def test_remove_no_project_error(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "project", "remove-input",
+            "--action", "jump",
+            "/nonexistent/path",
+        ])
+        assert result.exit_code != 0
+
+    def test_remove_then_list_empty(self, tmp_path: Path) -> None:
+        """After removing all actions, list-inputs shows empty."""
+        _make_project_with_inputs(tmp_path)
+        runner = CliRunner()
+        runner.invoke(cli, [
+            "project", "remove-input", "--action", "move_up",
+            str(tmp_path),
+        ])
+        runner.invoke(cli, [
+            "project", "remove-input", "--action", "jump",
+            str(tmp_path),
+        ])
+        result = runner.invoke(cli, [
+            "-j", "project", "list-inputs", str(tmp_path),
+        ])
+        data = json.loads(result.output)
+        assert data["count"] == 0
+
+    def test_remove_then_re_add(self, tmp_path: Path) -> None:
+        """Can add an action back after removing it."""
+        _make_project_with_inputs(tmp_path)
+        runner = CliRunner()
+        runner.invoke(cli, [
+            "project", "remove-input", "--action", "jump",
+            str(tmp_path),
+        ])
+        result = runner.invoke(cli, [
+            "project", "add-input",
+            "--action", "jump", "--key", "enter",
+            str(tmp_path),
+        ])
+        assert result.exit_code == 0
+        text = (tmp_path / "project.godot").read_text()
+        assert "jump=" in text
+
+
+class TestRemoveInputJson:
+    """Verify JSON output for remove-input."""
+
+    def test_json_output(self, tmp_path: Path) -> None:
+        _make_project_with_inputs(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "-j", "project", "remove-input",
+            "--action", "jump",
+            str(tmp_path),
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["removed"] is True
+        assert data["action"] == "jump"
+
+    def test_json_error_not_found(self, tmp_path: Path) -> None:
+        _make_project(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "-j", "project", "remove-input",
+            "--action", "nonexistent",
+            str(tmp_path),
+        ])
+        assert result.exit_code != 0


### PR DESCRIPTION
## Summary

- Add `project list-inputs` -- displays all input actions with binding summaries
- Add `project remove-input` -- removes an input action by name from project.godot
- 16 new tests covering both commands, JSON output, and error cases
- `add-input` already existed; this completes the input action management suite

## New commands

```bash
# List all input actions
auto-godot project list-inputs
auto-godot --json project list-inputs

# Remove an input action
auto-godot project remove-input --action jump
```

## Test plan

- [x] 1365 tests pass (1349 existing + 16 new)
- [x] List empty project, project with actions, JSON output
- [x] Remove existing action, nonexistent action error
- [x] Round-trip: add -> list -> remove -> list

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)