### PR TITLE
feat: add .claude/rules/ for scene-building and sprite-pipeline guidance

### DIFF
--- a/.claude/rules/scene-building.md
+++ b/.claude/rules/scene-building.md
@@ -1,0 +1,44 @@
+---
+paths:
+  - "scenes/**/*"
+  - "*.tscn"
+---
+
+# Scene Building Rules
+
+## Node Type Compatibility
+
+- CenterContainer only centers Control children. AnimatedSprite2D inherits
+  Node2D, so CenterContainer will not position it. Wrap in a Control node
+  with `mouse_filter = 2` (IGNORE) if needed.
+- For UI games (clickers, card games, menus), use a Control root node,
+  not Node2D. Set anchor preset `full_rect` on the root.
+
+## Container Layout
+
+- Children of VBoxContainer/HBoxContainer need `size_flags_vertical = 3`
+  (FILL + EXPAND) to fill available space. Without this, children collapse.
+- ScrollContainer children need explicit `size_flags_horizontal = 3` and
+  `size_flags_vertical = 3` to fill the scroll area.
+
+## Render Order and Input
+
+- Node order in the scene tree equals render order. Later siblings render
+  on top of earlier ones.
+- Later siblings block mouse input. Set `mouse_filter = 2` (IGNORE) on
+  non-interactive overlays, or they swallow clicks meant for nodes behind.
+
+## Visibility
+
+- PanelContainer is invisible by default. It needs a Theme or StyleBoxFlat
+  override to render.
+
+## Size Flags Reference
+
+| Value | Meaning |
+|-------|---------|
+| 0 | FILL (default) |
+| 1 | EXPAND |
+| 3 | FILL + EXPAND |
+| 4 | SHRINK_CENTER |
+| 6 | SHRINK_CENTER + EXPAND |

--- a/.claude/rules/sprite-pipeline.md
+++ b/.claude/rules/sprite-pipeline.md
@@ -1,0 +1,45 @@
+---
+paths:
+  - "assets/sprites/**/*"
+  - "art/**/*"
+  - "*.tres"
+  - "*.aseprite"
+---
+
+# Sprite Pipeline Rules
+
+## Import Workflow
+
+1. Export from Aseprite with `--format json-array` (not json-hash)
+2. Run `auto-godot sprite import-aseprite` to generate .tres SpriteFrames
+3. Run `godot --headless --import` to sync UIDs and generate .import files
+4. Run `auto-godot sprite validate` to check SpriteFrames structure
+
+## Common Pitfalls
+
+- After `sprite import-aseprite`, always run `godot --headless --import`
+  to generate .import files and assign UIDs. Without this, ExtResource
+  paths break at runtime.
+- Verify .tres ext_resource paths are full `res://` paths relative to the
+  project root, not bare filenames.
+- Use `auto-godot sprite list-animations` to verify animation names match
+  what scripts reference. Mismatched names cause silent failures.
+
+## ExtResource Format
+
+Generated .tscn/.tres files must use bare ExtResource syntax:
+- Correct: `ExtResource("1_script")`
+- Wrong: `"ExtResource(\"1_script\")"`
+
+If you see escaped quotes inside ExtResource values, the serializer has
+a bug.
+
+## Aseprite Export Settings
+
+When exporting from Aseprite CLI for auto-godot:
+```
+aseprite -b --sheet <output.png> --data <output.json> --format json-array <input.aseprite>
+```
+
+The `--format json-array` flag is required. json-hash format is not
+supported by `sprite import-aseprite`.


### PR DESCRIPTION
## Summary

- Add `scene-building.md` -- path-scoped rules for .tscn files covering node types, containers, render order, input blocking
- Add `sprite-pipeline.md` -- path-scoped rules for sprite assets covering import workflow, ExtResource format, Aseprite settings

These load automatically when Claude works on matching file paths.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)