### PR TITLE
fix: replace Variant-inferred := with explicit annotation in add-method (#70)

### DIFF
--- a/src/auto_godot/commands/script.py
+++ b/src/auto_godot/commands/script.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -9,6 +10,35 @@ import rich_click as click
 
 from auto_godot.errors import ProjectError
 from auto_godot.output import emit, emit_error
+
+# Functions/methods known to return Variant in GDScript. When := is used
+# with these, Godot 4.6 treats the inferred Variant type as an error.
+# Pattern: var name := <call> where <call> matches one of these.
+_VARIANT_RETURNING_CALLS: re.Pattern[str] = re.compile(
+    r"(JSON\.parse_string|\.pop_front|\.pop_back|\.pop_at|\.get\(|"
+    r"\.front\(\)|\.back\(\)|\.reduce\(|\.min\(\)|\.max\(\))"
+)
+
+# Matches: var <name> := <expression>
+_WALRUS_VAR: re.Pattern[str] = re.compile(
+    r"^(\s*var\s+\w+)\s*:=\s*(.+)$"
+)
+
+
+def _fix_variant_inference(line: str) -> str:
+    """Replace var x := expr with var x: Variant = expr for Variant-returning calls.
+
+    Godot 4.6 treats Variant inference via := as an error. This function
+    detects known Variant-returning expressions and adds an explicit
+    Variant annotation to prevent the compile error.
+    """
+    match = _WALRUS_VAR.match(line)
+    if not match:
+        return line
+    var_decl, expr = match.group(1), match.group(2)
+    if _VARIANT_RETURNING_CALLS.search(expr):
+        return f"{var_decl}: Variant = {expr}"
+    return line
 
 
 @click.group(invoke_without_command=True)
@@ -484,6 +514,7 @@ def add_method(
             f"func {method_name}({param_str}) -> {return_type}:",
         ]
         for body_line in body.replace("\\n", "\n").replace("\\t", "\t").split("\n"):
+            body_line = _fix_variant_inference(body_line)
             method_lines.append(f"\t{body_line}")
 
         insert_idx = _find_insert_point(lines, "method")

--- a/tests/unit/test_new_commands.py
+++ b/tests/unit/test_new_commands.py
@@ -1072,6 +1072,47 @@ class TestScriptAddMethod:
         assert data["added"] is True
         assert data["method"] == "heal"
 
+    def test_add_method_fixes_variant_inference(self, tmp_path: Path) -> None:
+        gd = _make_script(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "script", "add-method",
+            "--file", str(gd),
+            "--name", "load_data",
+            "--body", "var data := JSON.parse_string(some_text)",
+        ])
+        assert result.exit_code == 0, result.output
+        text = gd.read_text()
+        assert "var data: Variant = JSON.parse_string(some_text)" in text
+        assert ":=" not in text
+
+    def test_add_method_preserves_safe_walrus(self, tmp_path: Path) -> None:
+        gd = _make_script(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "script", "add-method",
+            "--file", str(gd),
+            "--name", "compute",
+            "--body", "var x := 5 + 3",
+        ])
+        assert result.exit_code == 0, result.output
+        text = gd.read_text()
+        # Non-Variant := should be preserved
+        assert "var x := 5 + 3" in text
+
+    def test_add_method_fixes_dict_get_variant(self, tmp_path: Path) -> None:
+        gd = _make_script(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "script", "add-method",
+            "--file", str(gd),
+            "--name", "get_value",
+            "--body", "var val := my_dict.get(key)",
+        ])
+        assert result.exit_code == 0, result.output
+        text = gd.read_text()
+        assert "var val: Variant = my_dict.get(key)" in text
+
 
 # ===================================================================
 # script add-var


### PR DESCRIPTION
## Summary

- `script add-method` now detects `var x := expr` where `expr` returns Variant and rewrites to `var x: Variant = expr`
- Prevents Godot 4.6 compile error: "The variable type is being inferred from a Variant value"
- Known Variant-returning patterns: `JSON.parse_string`, `.get()`, `.pop_front()`, `.pop_back()`, `.pop_at()`, `.front()`, `.back()`, `.reduce()`, `.min()`, `.max()`
- Non-Variant `:=` patterns (e.g., `var x := 5 + 3`) are preserved unchanged
- 3 new tests covering: Variant fix, safe walrus preservation, dict.get() Variant fix

Fixes #70

## Test plan

- [x] `test_add_method_fixes_variant_inference` -- JSON.parse_string case
- [x] `test_add_method_preserves_safe_walrus` -- non-Variant := preserved
- [x] `test_add_method_fixes_dict_get_variant` -- .get() case
- [x] Full suite: 1386 tests pass
- [ ] Manual: `auto-godot script add-method --body "var data := JSON.parse_string(text)"` produces `var data: Variant = ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)