### PR TITLE
feat: add locale command group for translation management (#43)

### DIFF
--- a/src/auto_godot/cli.py
+++ b/src/auto_godot/cli.py
@@ -28,6 +28,7 @@ from auto_godot.commands.animation import animation
 from auto_godot.commands.audio import audio
 from auto_godot.commands.debug import debug
 from auto_godot.commands.export import export
+from auto_godot.commands.locale import locale
 from auto_godot.commands.particle import particle
 from auto_godot.commands.physics import physics
 from auto_godot.commands.preset import preset
@@ -212,6 +213,7 @@ def _detect_tool(name: str, candidates: list[str]) -> dict[str, Any]:
 cli.add_command(animation)
 cli.add_command(audio)
 cli.add_command(debug)
+cli.add_command(locale)
 cli.add_command(project)
 cli.add_command(resource)
 cli.add_command(export)

--- a/src/auto_godot/commands/locale.py
+++ b/src/auto_godot/commands/locale.py
@@ -1,0 +1,333 @@
+"""Manage Godot translation/localization CSV files."""
+
+from __future__ import annotations
+
+import csv
+import io
+import re
+from pathlib import Path
+from typing import Any
+
+import rich_click as click
+
+from auto_godot.errors import ProjectError
+from auto_godot.output import emit, emit_error
+
+
+@click.group(invoke_without_command=True)
+@click.pass_context
+def locale(ctx: click.Context) -> None:
+    """Manage Godot localization and translation files."""
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+def _read_csv(path: Path) -> tuple[list[str], list[dict[str, str]]]:
+    """Read a translation CSV, returning (headers, rows as dicts)."""
+    text = path.read_text(encoding="utf-8")
+    reader = csv.DictReader(io.StringIO(text))
+    headers = reader.fieldnames or []
+    rows = list(reader)
+    return list(headers), rows
+
+
+def _write_csv(path: Path, headers: list[str], rows: list[dict[str, str]]) -> None:
+    """Write translation CSV with consistent formatting."""
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=headers, lineterminator="\n")
+    writer.writeheader()
+    writer.writerows(rows)
+    path.write_text(buf.getvalue(), encoding="utf-8")
+
+
+@locale.command("create")
+@click.argument("csv_file", type=click.Path())
+@click.option(
+    "--default", "default_locale", default="en",
+    help="Default locale column. Default: en.",
+)
+@click.pass_context
+def create(ctx: click.Context, csv_file: str, default_locale: str) -> None:
+    """Create a translation CSV with a default locale column.
+
+    Examples:
+
+      auto-godot locale create translations.csv
+
+      auto-godot locale create translations.csv --default ja
+    """
+    try:
+        path = Path(csv_file)
+        if path.exists():
+            raise ProjectError(
+                message=f"File already exists: {csv_file}",
+                code="FILE_EXISTS",
+                fix="Choose a different filename or delete the existing file",
+            )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _write_csv(path, ["keys", default_locale], [])
+        data = {"created": True, "path": csv_file, "locale": default_locale}
+
+        def _human(d: dict[str, Any], verbose: bool = False) -> None:
+            click.echo(f"Created {d['path']} with default locale '{d['locale']}'")
+
+        emit(data, _human, ctx)
+    except ProjectError as exc:
+        emit_error(exc, ctx)
+
+
+@locale.command("add-locale")
+@click.argument("csv_file", type=click.Path(exists=True))
+@click.argument("locale_code")
+@click.pass_context
+def add_locale(ctx: click.Context, csv_file: str, locale_code: str) -> None:
+    """Add a locale column to a translation CSV.
+
+    Examples:
+
+      auto-godot locale add-locale translations.csv es
+
+      auto-godot locale add-locale translations.csv ja
+    """
+    try:
+        path = Path(csv_file)
+        headers, rows = _read_csv(path)
+        if locale_code in headers:
+            raise ProjectError(
+                message=f"Locale '{locale_code}' already exists in {csv_file}",
+                code="LOCALE_EXISTS",
+                fix="Choose a different locale code",
+            )
+        headers.append(locale_code)
+        for row in rows:
+            row[locale_code] = ""
+        _write_csv(path, headers, rows)
+        data = {"added": True, "locale": locale_code, "file": csv_file}
+
+        def _human(d: dict[str, Any], verbose: bool = False) -> None:
+            click.echo(f"Added locale '{d['locale']}' to {d['file']}")
+
+        emit(data, _human, ctx)
+    except ProjectError as exc:
+        emit_error(exc, ctx)
+
+
+@locale.command("add-key")
+@click.argument("csv_file", type=click.Path(exists=True))
+@click.argument("key")
+@click.option(
+    "--value", "values", multiple=True,
+    help="Locale=value pairs. E.g., --value en=Start --value es=Iniciar.",
+)
+@click.pass_context
+def add_key(
+    ctx: click.Context, csv_file: str, key: str, values: tuple[str, ...]
+) -> None:
+    """Add a translation key with optional locale values.
+
+    Examples:
+
+      auto-godot locale add-key translations.csv MENU_START --value "en=Start Game" --value "es=Iniciar Juego"
+
+      auto-godot locale add-key translations.csv MENU_QUIT --value "en=Quit"
+    """
+    try:
+        path = Path(csv_file)
+        headers, rows = _read_csv(path)
+
+        # Check for duplicate key
+        existing_keys = {row.get("keys", "") for row in rows}
+        if key in existing_keys:
+            raise ProjectError(
+                message=f"Key '{key}' already exists in {csv_file}",
+                code="KEY_EXISTS",
+                fix="Choose a different key name or edit the existing one",
+            )
+
+        new_row: dict[str, str] = {"keys": key}
+        for h in headers:
+            if h != "keys":
+                new_row[h] = ""
+
+        # Parse locale=value pairs
+        for val_str in values:
+            if "=" not in val_str:
+                raise ProjectError(
+                    message=f"Invalid value format: '{val_str}'",
+                    code="INVALID_VALUE",
+                    fix="Use locale=value format, e.g., --value en=Start",
+                )
+            loc, text = val_str.split("=", 1)
+            if loc not in headers:
+                raise ProjectError(
+                    message=f"Locale '{loc}' not in CSV. Available: {headers[1:]}",
+                    code="LOCALE_NOT_FOUND",
+                    fix=f"Add the locale first: auto-godot locale add-locale {csv_file} {loc}",
+                )
+            new_row[loc] = text
+
+        rows.append(new_row)
+        _write_csv(path, headers, rows)
+
+        data = {"added": True, "key": key, "file": csv_file}
+
+        def _human(d: dict[str, Any], verbose: bool = False) -> None:
+            click.echo(f"Added key '{d['key']}' to {d['file']}")
+
+        emit(data, _human, ctx)
+    except ProjectError as exc:
+        emit_error(exc, ctx)
+
+
+@locale.command("list-keys")
+@click.argument("csv_file", type=click.Path(exists=True))
+@click.pass_context
+def list_keys(ctx: click.Context, csv_file: str) -> None:
+    """List all translation keys in a CSV file.
+
+    Examples:
+
+      auto-godot locale list-keys translations.csv
+
+      auto-godot --json locale list-keys translations.csv
+    """
+    path = Path(csv_file)
+    headers, rows = _read_csv(path)
+    keys = [row.get("keys", "") for row in rows]
+    data = {"keys": keys, "count": len(keys), "file": csv_file}
+
+    def _human(d: dict[str, Any], verbose: bool = False) -> None:
+        click.echo(f"Keys in {d['file']} ({d['count']}):")
+        for k in d["keys"]:
+            click.echo(f"  {k}")
+
+    emit(data, _human, ctx)
+
+
+@locale.command("list-locales")
+@click.argument("csv_file", type=click.Path(exists=True))
+@click.pass_context
+def list_locales(ctx: click.Context, csv_file: str) -> None:
+    """List all locale columns in a translation CSV.
+
+    Examples:
+
+      auto-godot locale list-locales translations.csv
+    """
+    path = Path(csv_file)
+    headers, _rows = _read_csv(path)
+    locales = [h for h in headers if h != "keys"]
+    data = {"locales": locales, "count": len(locales), "file": csv_file}
+
+    def _human(d: dict[str, Any], verbose: bool = False) -> None:
+        click.echo(f"Locales in {d['file']} ({d['count']}):")
+        for loc in d["locales"]:
+            click.echo(f"  {loc}")
+
+    emit(data, _human, ctx)
+
+
+@locale.command("audit")
+@click.argument("csv_file", type=click.Path(exists=True))
+@click.pass_context
+def audit(ctx: click.Context, csv_file: str) -> None:
+    """Find missing translations (keys with empty values for any locale).
+
+    Examples:
+
+      auto-godot locale audit translations.csv
+
+      auto-godot --json locale audit translations.csv
+    """
+    path = Path(csv_file)
+    headers, rows = _read_csv(path)
+    locales = [h for h in headers if h != "keys"]
+
+    missing: list[dict[str, str]] = []
+    for row in rows:
+        key = row.get("keys", "")
+        for loc in locales:
+            val = row.get(loc, "").strip()
+            if not val:
+                missing.append({"key": key, "locale": loc})
+
+    data = {
+        "file": csv_file,
+        "total_keys": len(rows),
+        "total_locales": len(locales),
+        "missing": missing,
+        "missing_count": len(missing),
+        "complete": len(missing) == 0,
+    }
+
+    def _human(d: dict[str, Any], verbose: bool = False) -> None:
+        click.echo(f"Audit: {d['file']}")
+        click.echo(f"  Keys: {d['total_keys']}, Locales: {d['total_locales']}")
+        if d["complete"]:
+            click.echo("  All translations complete.")
+        else:
+            click.echo(f"  Missing translations: {d['missing_count']}")
+            for m in d["missing"]:
+                click.echo(f"    {m['key']} [{m['locale']}]")
+
+    emit(data, _human, ctx)
+    if not data["complete"]:
+        ctx.exit(1)
+
+
+@locale.command("extract")
+@click.argument("project_path", default=".", type=click.Path(exists=True))
+@click.option(
+    "-o", "--output", type=click.Path(),
+    help="Write extracted keys to a CSV file.",
+)
+@click.pass_context
+def extract(ctx: click.Context, project_path: str, output: str | None) -> None:
+    """Extract translatable strings from GDScript tr() calls.
+
+    Scans .gd files for tr("KEY") patterns and reports all translation
+    keys used in the project.
+
+    Examples:
+
+      auto-godot locale extract /path/to/project
+
+      auto-godot locale extract . --output keys.csv
+    """
+    root = Path(project_path)
+    tr_pattern = re.compile(r'\btr\(\s*"([^"]+)"\s*\)')
+    found_keys: dict[str, list[str]] = {}  # key -> [file paths]
+
+    for gd_file in root.rglob("*.gd"):
+        if ".godot" in gd_file.parts or ".import" in gd_file.parts:
+            continue
+        try:
+            text = gd_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for match in tr_pattern.finditer(text):
+            key = match.group(1)
+            rel = str(gd_file.relative_to(root))
+            found_keys.setdefault(key, []).append(rel)
+
+    data: dict[str, Any] = {
+        "keys": sorted(found_keys.keys()),
+        "count": len(found_keys),
+        "sources": {k: v for k, v in sorted(found_keys.items())},
+    }
+
+    if output:
+        out_path = Path(output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        _write_csv(out_path, ["keys", "en"], [{"keys": k, "en": ""} for k in sorted(found_keys)])
+        data["output_file"] = output
+
+    def _human(d: dict[str, Any], verbose: bool = False) -> None:
+        click.echo(f"Found {d['count']} translatable key(s):")
+        for k in d["keys"]:
+            sources = d["sources"][k]
+            click.echo(f"  {k} (in {', '.join(sources)})")
+        if "output_file" in d:
+            click.echo(f"\nWrote keys to {d['output_file']}")
+
+    emit(data, _human, ctx)

--- a/tests/unit/test_locale_commands.py
+++ b/tests/unit/test_locale_commands.py
@@ -1,0 +1,219 @@
+"""Tests for locale (localization/translation) commands."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from auto_godot.cli import cli
+
+
+def _make_csv(tmp_path: Path, name: str = "translations.csv") -> Path:
+    """Create a test translation CSV."""
+    csv_path = tmp_path / name
+    csv_path.write_text("keys,en,es\nMENU_START,Start Game,Iniciar Juego\nMENU_QUIT,Quit,\n")
+    return csv_path
+
+
+class TestLocaleCreate:
+    """Verify locale create makes a translation CSV."""
+
+    def test_create_default(self, tmp_path: Path) -> None:
+        csv_path = tmp_path / "translations.csv"
+        runner = CliRunner()
+        result = runner.invoke(cli, ["locale", "create", str(csv_path)])
+        assert result.exit_code == 0, result.output
+        assert csv_path.exists()
+        text = csv_path.read_text()
+        assert "keys,en" in text
+
+    def test_create_custom_locale(self, tmp_path: Path) -> None:
+        csv_path = tmp_path / "translations.csv"
+        runner = CliRunner()
+        result = runner.invoke(cli, ["locale", "create", str(csv_path), "--default", "ja"])
+        assert result.exit_code == 0
+        text = csv_path.read_text()
+        assert "keys,ja" in text
+
+    def test_create_fails_if_exists(self, tmp_path: Path) -> None:
+        csv_path = _make_csv(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["locale", "create", str(csv_path)])
+        assert result.exit_code != 0
+
+    def test_create_json(self, tmp_path: Path) -> None:
+        csv_path = tmp_path / "translations.csv"
+        runner = CliRunner()
+        result = runner.invoke(cli, ["-j", "locale", "create", str(csv_path)])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["created"] is True
+
+
+class TestLocaleAddLocale:
+    """Verify locale add-locale adds a column."""
+
+    def test_add_locale(self, tmp_path: Path) -> None:
+        csv_path = _make_csv(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["locale", "add-locale", str(csv_path), "ja"])
+        assert result.exit_code == 0, result.output
+        text = csv_path.read_text()
+        assert "ja" in text.split("\n")[0]
+
+    def test_add_duplicate_locale(self, tmp_path: Path) -> None:
+        csv_path = _make_csv(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["locale", "add-locale", str(csv_path), "en"])
+        assert result.exit_code != 0
+
+
+class TestLocaleAddKey:
+    """Verify locale add-key inserts translation rows."""
+
+    def test_add_key_with_values(self, tmp_path: Path) -> None:
+        csv_path = _make_csv(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "locale", "add-key", str(csv_path), "MENU_OPTIONS",
+            "--value", "en=Options", "--value", "es=Opciones",
+        ])
+        assert result.exit_code == 0, result.output
+        text = csv_path.read_text()
+        assert "MENU_OPTIONS" in text
+        assert "Options" in text
+        assert "Opciones" in text
+
+    def test_add_key_empty_values(self, tmp_path: Path) -> None:
+        csv_path = _make_csv(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["locale", "add-key", str(csv_path), "NEW_KEY"])
+        assert result.exit_code == 0
+        reader = csv.DictReader(io.StringIO(csv_path.read_text()))
+        rows = list(reader)
+        new_row = [r for r in rows if r["keys"] == "NEW_KEY"]
+        assert len(new_row) == 1
+
+    def test_add_duplicate_key(self, tmp_path: Path) -> None:
+        csv_path = _make_csv(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["locale", "add-key", str(csv_path), "MENU_START"])
+        assert result.exit_code != 0
+
+    def test_add_key_invalid_locale(self, tmp_path: Path) -> None:
+        csv_path = _make_csv(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "locale", "add-key", str(csv_path), "TEST",
+            "--value", "fr=Test",
+        ])
+        assert result.exit_code != 0  # fr not in CSV
+
+
+class TestLocaleListKeys:
+    """Verify locale list-keys shows all keys."""
+
+    def test_list_keys(self, tmp_path: Path) -> None:
+        csv_path = _make_csv(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["locale", "list-keys", str(csv_path)])
+        assert result.exit_code == 0
+        assert "MENU_START" in result.output
+        assert "MENU_QUIT" in result.output
+
+    def test_list_keys_json(self, tmp_path: Path) -> None:
+        csv_path = _make_csv(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["-j", "locale", "list-keys", str(csv_path)])
+        data = json.loads(result.output)
+        assert data["count"] == 2
+        assert "MENU_START" in data["keys"]
+
+
+class TestLocaleListLocales:
+    """Verify locale list-locales shows locale columns."""
+
+    def test_list_locales(self, tmp_path: Path) -> None:
+        csv_path = _make_csv(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["locale", "list-locales", str(csv_path)])
+        assert result.exit_code == 0
+        assert "en" in result.output
+        assert "es" in result.output
+
+    def test_list_locales_json(self, tmp_path: Path) -> None:
+        csv_path = _make_csv(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["-j", "locale", "list-locales", str(csv_path)])
+        data = json.loads(result.output)
+        assert data["count"] == 2
+        assert "en" in data["locales"]
+        assert "es" in data["locales"]
+
+
+class TestLocaleAudit:
+    """Verify locale audit finds missing translations."""
+
+    def test_audit_finds_missing(self, tmp_path: Path) -> None:
+        csv_path = _make_csv(tmp_path)  # MENU_QUIT has empty es value
+        runner = CliRunner()
+        result = runner.invoke(cli, ["-j", "locale", "audit", str(csv_path)])
+        data = json.loads(result.output)
+        assert not data["complete"]
+        assert data["missing_count"] > 0
+        missing_keys = [m["key"] for m in data["missing"]]
+        assert "MENU_QUIT" in missing_keys
+
+    def test_audit_complete(self, tmp_path: Path) -> None:
+        csv_path = tmp_path / "complete.csv"
+        csv_path.write_text("keys,en\nHELLO,Hello\nBYE,Bye\n")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["-j", "locale", "audit", str(csv_path)])
+        data = json.loads(result.output)
+        assert data["complete"]
+        assert result.exit_code == 0
+
+
+class TestLocaleExtract:
+    """Verify locale extract finds tr() keys in GDScript files."""
+
+    def test_extract_finds_keys(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        (scripts_dir / "main.gd").write_text(
+            'extends Node\n\n'
+            'func _ready() -> void:\n'
+            '\tvar label := $Label\n'
+            '\tlabel.text = tr("HELLO_WORLD")\n'
+            '\tprint(tr("GOODBYE"))\n'
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["-j", "locale", "extract", str(tmp_path)])
+        data = json.loads(result.output)
+        assert data["count"] == 2
+        assert "HELLO_WORLD" in data["keys"]
+        assert "GOODBYE" in data["keys"]
+
+    def test_extract_writes_csv(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        (scripts_dir / "main.gd").write_text('func test():\n\ttr("KEY1")\n')
+        out_csv = tmp_path / "keys.csv"
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "locale", "extract", str(tmp_path), "-o", str(out_csv)
+        ])
+        assert result.exit_code == 0
+        assert out_csv.exists()
+        text = out_csv.read_text()
+        assert "KEY1" in text
+
+    def test_extract_empty_project(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["-j", "locale", "extract", str(tmp_path)])
+        data = json.loads(result.output)
+        assert data["count"] == 0


### PR DESCRIPTION
## Summary

- Adds new `auto-godot locale` command group with 7 subcommands:
  - `create` -- create translation CSV with default locale
  - `add-locale` -- add locale column to existing CSV
  - `add-key` -- add translation key with optional values per locale
  - `list-keys` -- list all translation keys
  - `list-locales` -- list all locale columns
  - `audit` -- find missing translations (keys with empty values)
  - `extract` -- scan .gd files for `tr("KEY")` patterns, optionally write to CSV
- All commands support `--json` output
- Standard error handling with error codes and fix suggestions
- 19 new tests covering all commands

Closes #43

## Test plan

- [x] 19 locale command tests pass
- [x] Full suite: 1405 tests pass
- [ ] Manual: create CSV, add locales, add keys, audit for missing
- [ ] Manual: extract tr() keys from a real Godot project
- [ ] Verify CSV format is compatible with Godot's translation import

🤖 Generated with [Claude Code](https://claude.com/claude-code)