### PR TITLE
feat: package Claude Code integration as distributable plugin (#50)

### DIFF
--- a/.claude-plugin/hooks.json
+++ b/.claude-plugin/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python ${CLAUDE_PLUGIN_ROOT}/.claude/hooks/check_auto_godot_output.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "auto-godot",
+  "version": "1.0.0",
+  "description": "Claude Code integration for auto-godot: Godot scene debugging, validation, and game build workflows",
+  "author": {
+    "name": "Wundrfull",
+    "url": "https://github.com/Wundrfull"
+  },
+  "repository": "https://github.com/Wundrfull/auto-godot",
+  "license": "Apache-2.0",
+  "keywords": ["godot", "gamedev", "automation", "scene-builder", "spriteframes"],
+  "skills": "./.claude/skills/",
+  "agents": "./.claude/agents/",
+  "hooks": "./.claude-plugin/hooks.json"
+}


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/plugin.json` manifest for Claude Code plugin distribution
- References existing components: 3 skills, 1 agent, output validation hooks
- Portable `hooks.json` uses `${CLAUDE_PLUGIN_ROOT}` for path resolution
- Users install with: `claude --plugin-dir ./auto-godot`
- Plugin does NOT bundle the CLI binary -- users install `auto-godot` separately via `pip install auto-godot`

Design decisions (from open questions in #50):
- **In main repo** (not separate) -- all assets already here, simpler to maintain
- **Reference CLI, don't bundle** -- plugin is the knowledge layer, CLI is the tool
- **Marketplace deferred** -- ship structure now, publish later

Closes #50

## Test plan

- [ ] `claude --plugin-dir .` loads the plugin without errors
- [ ] Skills appear as `/auto-godot:validate`, `/auto-godot:fix-scene`, `/auto-godot:build-game`
- [ ] Agent appears as `@gdauto-expert`
- [ ] PostToolUse hook fires after auto-godot Bash commands
- [x] 1422 unit tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)