### PR TITLE
feat: add GDScript documentation generator (#81)

### DIFF
--- a/src/auto_godot/commands/script.py
+++ b/src/auto_godot/commands/script.py
@@ -807,3 +807,94 @@ def list_vars(ctx: click.Context, file_path: str) -> None:
             ),
             ctx,
         )
+
+
+# ---------------------------------------------------------------------------
+# script docs
+# ---------------------------------------------------------------------------
+
+
+@script.command("docs")
+@click.argument("path", type=click.Path(exists=True))
+@click.option(
+    "-o", "--output",
+    "output_dir",
+    type=click.Path(),
+    default=None,
+    help="Output directory for generated Markdown docs.",
+)
+@click.pass_context
+def docs(ctx: click.Context, path: str, output_dir: str | None) -> None:
+    """Generate documentation from GDScript files.
+
+    Parses ## doc comments, signals, exports, functions, enums, and
+    constants from .gd files. Accepts a single file or a project
+    directory (recursively finds all .gd files).
+
+    Examples:
+
+      auto-godot script docs scripts/player.gd
+
+      auto-godot script docs /path/to/project -o docs/
+
+      auto-godot --json script docs scripts/player.gd
+    """
+    from auto_godot.gdscript_docs import format_markdown, parse_gdscript
+
+    try:
+        target = Path(path)
+        gd_files: list[Path] = []
+
+        if target.is_file():
+            if not target.suffix == ".gd":
+                raise ProjectError(
+                    message=f"Not a GDScript file: {path}",
+                    code="NOT_GDSCRIPT",
+                    fix="Provide a .gd file or a directory containing .gd files",
+                )
+            gd_files.append(target)
+        else:
+            gd_files = sorted(target.rglob("*.gd"))
+            if not gd_files:
+                raise ProjectError(
+                    message=f"No .gd files found in {path}",
+                    code="NO_SCRIPTS_FOUND",
+                    fix="Check the directory path contains GDScript files",
+                )
+
+        results: list[dict[str, Any]] = []
+        for gd_file in gd_files:
+            text = gd_file.read_text(encoding="utf-8")
+            script_doc = parse_gdscript(text, str(gd_file))
+            results.append(script_doc.to_dict())
+
+            if output_dir is not None:
+                out_path = Path(output_dir)
+                out_path.mkdir(parents=True, exist_ok=True)
+                md_name = gd_file.stem + ".md"
+                md_path = out_path / md_name
+                md_path.write_text(format_markdown(script_doc), encoding="utf-8")
+
+        data: dict[str, Any] = {
+            "scripts": results,
+            "count": len(results),
+        }
+        if output_dir is not None:
+            data["output_dir"] = output_dir
+
+        def _human(data: dict[str, Any], verbose: bool = False) -> None:
+            if data.get("output_dir"):
+                click.echo(
+                    f"Generated docs for {data['count']} script(s) "
+                    f"in {data['output_dir']}/"
+                )
+                return
+            # Single-file mode without -o: print markdown to stdout
+            for script_data in data["scripts"]:
+                gd_text = Path(script_data["path"]).read_text(encoding="utf-8")
+                sd = parse_gdscript(gd_text, script_data["path"])
+                click.echo(format_markdown(sd))
+
+        emit(data, _human, ctx)
+    except ProjectError as exc:
+        emit_error(exc, ctx)

--- a/src/auto_godot/commands/script.py
+++ b/src/auto_godot/commands/script.py
@@ -814,6 +814,72 @@ def list_vars(ctx: click.Context, file_path: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _collect_gd_files(path: str) -> list[Path]:
+    """Resolve path to a list of .gd files."""
+    target = Path(path)
+    if target.is_file():
+        if target.suffix != ".gd":
+            raise ProjectError(
+                message=f"Not a GDScript file: {path}",
+                code="NOT_GDSCRIPT",
+                fix="Provide a .gd file or a directory containing .gd files",
+            )
+        return [target]
+    gd_files = sorted(target.rglob("*.gd"))
+    if not gd_files:
+        raise ProjectError(
+            message=f"No .gd files found in {path}",
+            code="NO_SCRIPTS_FOUND",
+            fix="Check the directory path contains GDScript files",
+        )
+    return gd_files
+
+
+def _write_docs_output(
+    gd_files: list[Path], output_dir: str, base_dir: Path,
+) -> list[dict[str, Any]]:
+    """Parse files and write Markdown docs, detecting stem collisions."""
+    from auto_godot.gdscript_docs import format_markdown, parse_gdscript
+
+    out_path = Path(output_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+    seen_stems: dict[str, Path] = {}
+    results: list[dict[str, Any]] = []
+    for gd_file in gd_files:
+        stem = gd_file.stem
+        if stem in seen_stems:
+            # Use relative path to disambiguate
+            try:
+                rel = gd_file.relative_to(base_dir)
+            except ValueError:
+                rel = gd_file
+            md_name = str(rel).replace("/", "_").replace("\\", "_")
+            md_name = md_name.rsplit(".", 1)[0] + ".md"
+        else:
+            md_name = stem + ".md"
+        seen_stems[stem] = gd_file
+        text = gd_file.read_text(encoding="utf-8")
+        sd = parse_gdscript(text, str(gd_file))
+        results.append(sd.to_dict())
+        (out_path / md_name).write_text(format_markdown(sd), encoding="utf-8")
+    return results
+
+
+def _display_docs(data: dict[str, Any], verbose: bool = False) -> None:
+    """Human-readable output for script docs."""
+    from auto_godot.gdscript_docs import format_markdown, parse_gdscript
+
+    if data.get("output_dir"):
+        click.echo(
+            f"Generated docs for {data['count']} script(s) "
+            f"in {data['output_dir']}/"
+        )
+        return
+    for script_data in data["scripts"]:
+        text = Path(script_data["path"]).read_text(encoding="utf-8")
+        click.echo(format_markdown(parse_gdscript(text, script_data["path"])))
+
+
 @script.command("docs")
 @click.argument("path", type=click.Path(exists=True))
 @click.option(
@@ -839,62 +905,26 @@ def docs(ctx: click.Context, path: str, output_dir: str | None) -> None:
 
       auto-godot --json script docs scripts/player.gd
     """
-    from auto_godot.gdscript_docs import format_markdown, parse_gdscript
+    from auto_godot.gdscript_docs import parse_gdscript
 
     try:
-        target = Path(path)
-        gd_files: list[Path] = []
-
-        if target.is_file():
-            if not target.suffix == ".gd":
-                raise ProjectError(
-                    message=f"Not a GDScript file: {path}",
-                    code="NOT_GDSCRIPT",
-                    fix="Provide a .gd file or a directory containing .gd files",
-                )
-            gd_files.append(target)
+        gd_files = _collect_gd_files(path)
+        if output_dir is not None:
+            results = _write_docs_output(gd_files, output_dir, Path(path))
         else:
-            gd_files = sorted(target.rglob("*.gd"))
-            if not gd_files:
-                raise ProjectError(
-                    message=f"No .gd files found in {path}",
-                    code="NO_SCRIPTS_FOUND",
-                    fix="Check the directory path contains GDScript files",
-                )
-
-        results: list[dict[str, Any]] = []
-        for gd_file in gd_files:
-            text = gd_file.read_text(encoding="utf-8")
-            script_doc = parse_gdscript(text, str(gd_file))
-            results.append(script_doc.to_dict())
-
-            if output_dir is not None:
-                out_path = Path(output_dir)
-                out_path.mkdir(parents=True, exist_ok=True)
-                md_name = gd_file.stem + ".md"
-                md_path = out_path / md_name
-                md_path.write_text(format_markdown(script_doc), encoding="utf-8")
-
-        data: dict[str, Any] = {
-            "scripts": results,
-            "count": len(results),
-        }
+            results = []
+            for gd_file in gd_files:
+                text = gd_file.read_text(encoding="utf-8")
+                results.append(parse_gdscript(text, str(gd_file)).to_dict())
+        data: dict[str, Any] = {"scripts": results, "count": len(results)}
         if output_dir is not None:
             data["output_dir"] = output_dir
-
-        def _human(data: dict[str, Any], verbose: bool = False) -> None:
-            if data.get("output_dir"):
-                click.echo(
-                    f"Generated docs for {data['count']} script(s) "
-                    f"in {data['output_dir']}/"
-                )
-                return
-            # Single-file mode without -o: print markdown to stdout
-            for script_data in data["scripts"]:
-                gd_text = Path(script_data["path"]).read_text(encoding="utf-8")
-                sd = parse_gdscript(gd_text, script_data["path"])
-                click.echo(format_markdown(sd))
-
-        emit(data, _human, ctx)
-    except ProjectError as exc:
+        emit(data, _display_docs, ctx)
+    except (ProjectError, OSError) as exc:
+        if isinstance(exc, OSError):
+            exc = ProjectError(
+                message=f"File error: {exc}",
+                code="IO_ERROR",
+                fix="Check file permissions and paths",
+            )
         emit_error(exc, ctx)

--- a/src/auto_godot/gdscript_docs.py
+++ b/src/auto_godot/gdscript_docs.py
@@ -1,0 +1,209 @@
+"""GDScript documentation extractor.
+
+Regex-based declaration extraction from .gd files. Produces structured
+dicts for JSON output and Markdown for human-readable docs.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Regex patterns for GDScript declarations
+_CLASS_NAME = re.compile(r"^class_name\s+(\w+)")
+_EXTENDS = re.compile(r"^extends\s+(\w+)")
+_SIGNAL = re.compile(r"^signal\s+(\w+)(?:\(([^)]*)\))?")
+_CONST = re.compile(r"^const\s+(\w+)(?:\s*:\s*\w+)?\s*=\s*(.+)")
+_EXPORT = re.compile(r"^@export(?:_\w+(?:\([^)]*\))?)?\s+var\s+(\w+)\s*(?::\s*([^=]+?))?\s*(?:=\s*(.+))?$")
+_VAR = re.compile(r"^var\s+(\w+)\s*(?::\s*([^=]+?))?\s*(?:=\s*(.+))?$")
+_FUNC = re.compile(r"^(static\s+)?func\s+(\w+)\s*\(([^)]*)\)\s*(?:->\s*(\w+))?")
+_ENUM_START = re.compile(r"^enum\s+(\w+)\s*\{(.*)")
+_DOC_COMMENT = re.compile(r"^##\s?(.*)")
+
+
+def _collect_doc(lines: list[str], end: int) -> str:
+    """Collect consecutive ## lines above index end (exclusive)."""
+    parts: list[str] = []
+    i = end - 1
+    while i >= 0:
+        m = _DOC_COMMENT.match(lines[i].strip())
+        if m:
+            parts.append(m.group(1))
+            i -= 1
+        else:
+            break
+    parts.reverse()
+    return "\n".join(parts).strip()
+
+
+def _parse_enum_values(lines: list[str], start: int, initial: str) -> list[str]:
+    """Parse enum values from braces, handling multi-line."""
+    combined = initial
+    i = start + 1
+    while "}" not in combined and i < len(lines):
+        combined += " " + lines[i].strip()
+        i += 1
+    body = combined.split("}", 1)[0]
+    return [v.strip() for v in body.split(",") if v.strip()]
+
+
+@dataclass
+class ScriptDoc:
+    """Documentation extracted from a single GDScript file."""
+    path: str
+    class_name: str | None = None
+    extends: str | None = None
+    description: str = ""
+    signals: list[dict[str, Any]] = field(default_factory=list)
+    constants: list[dict[str, Any]] = field(default_factory=list)
+    enums: list[dict[str, Any]] = field(default_factory=list)
+    exports: list[dict[str, Any]] = field(default_factory=list)
+    variables: list[dict[str, Any]] = field(default_factory=list)
+    functions: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {"path": self.path}
+        if self.class_name:
+            result["class_name"] = self.class_name
+        if self.extends:
+            result["extends"] = self.extends
+        if self.description:
+            result["description"] = self.description
+        for key in ("signals", "constants", "enums", "exports", "variables", "functions"):
+            items = getattr(self, key)
+            if items:
+                result[key] = items
+        return result
+
+
+def parse_gdscript(text: str, file_path: str = "") -> ScriptDoc:
+    """Parse a GDScript file and extract documentation."""
+    doc = ScriptDoc(path=file_path)
+    lines = text.split("\n")
+
+    # File-level doc comment (## lines before class_name/extends)
+    file_doc: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        m = _DOC_COMMENT.match(stripped)
+        if m:
+            file_doc.append(m.group(1))
+        elif stripped == "":
+            if file_doc:
+                break
+        else:
+            break
+    doc.description = "\n".join(file_doc).strip()
+
+    i = 0
+    while i < len(lines):
+        raw = lines[i]
+        s = raw.strip()
+        top = raw == s or raw == ""
+
+        if top and (m := _CLASS_NAME.match(s)):
+            doc.class_name = m.group(1)
+        elif top and (m := _EXTENDS.match(s)):
+            doc.extends = m.group(1)
+        elif top and (m := _ENUM_START.match(s)):
+            vals = _parse_enum_values(lines, i, m.group(2))
+            entry: dict[str, Any] = {"name": m.group(1), "values": vals, "line": i + 1}
+            comment = _collect_doc(lines, i)
+            if comment:
+                entry["doc"] = comment
+            doc.enums.append(entry)
+        elif top and (m := _SIGNAL.match(s)):
+            entry = {"name": m.group(1), "signature": s, "line": i + 1}
+            comment = _collect_doc(lines, i)
+            if comment:
+                entry["doc"] = comment
+            doc.signals.append(entry)
+        elif top and (m := _CONST.match(s)):
+            entry = {"name": m.group(1), "signature": s, "line": i + 1}
+            comment = _collect_doc(lines, i)
+            if comment:
+                entry["doc"] = comment
+            doc.constants.append(entry)
+        elif top and (m := _EXPORT.match(s)):
+            entry = {"name": m.group(1), "signature": s, "line": i + 1}
+            comment = _collect_doc(lines, i)
+            if comment:
+                entry["doc"] = comment
+            doc.exports.append(entry)
+        elif top and (m := _VAR.match(s)):
+            entry = {"name": m.group(1), "signature": s, "line": i + 1}
+            comment = _collect_doc(lines, i)
+            if comment:
+                entry["doc"] = comment
+            doc.variables.append(entry)
+        elif top and (m := _FUNC.match(s)):
+            entry = {
+                "name": m.group(2), "params": m.group(3).strip(),
+                "return_type": m.group(4) or "void", "line": i + 1,
+            }
+            if m.group(1):
+                entry["static"] = True
+            comment = _collect_doc(lines, i)
+            if comment:
+                entry["doc"] = comment
+            doc.functions.append(entry)
+        i += 1
+    return doc
+
+
+def format_markdown(sd: ScriptDoc) -> str:
+    """Format a ScriptDoc as Markdown."""
+    p: list[str] = []
+    title = sd.class_name or Path(sd.path).stem
+    p.append(f"# {title}\n")
+    if sd.extends:
+        p.append(f"**Extends:** `{sd.extends}`\n")
+    if sd.description:
+        p.append(sd.description + "\n")
+    if sd.signals:
+        p.append("## Signals\n")
+        for sig in sd.signals:
+            p.append(f"### `{sig['signature']}`\n")
+            if sig.get("doc"):
+                p.append(sig["doc"] + "\n")
+    if sd.enums:
+        p.append("## Enums\n")
+        for en in sd.enums:
+            p.append(f"### {en['name']}\n")
+            if en.get("doc"):
+                p.append(en["doc"] + "\n")
+            for val in en["values"]:
+                p.append(f"- `{val}`")
+            p.append("")
+    if sd.constants:
+        p.append("## Constants\n")
+        for c in sd.constants:
+            line = f"- `{c['signature']}`"
+            if c.get("doc"):
+                line += f"\n  {c['doc']}"
+            p.append(line + "\n")
+    if sd.exports:
+        p.append("## Exported Properties\n")
+        p.append("| Name | Declaration | Description |")
+        p.append("|------|-------------|-------------|")
+        for exp in sd.exports:
+            doc_cell = exp.get("doc", "").replace("\n", " ")
+            p.append(f"| {exp['name']} | `{exp['signature']}` | {doc_cell} |")
+        p.append("")
+    if sd.variables:
+        p.append("## Variables\n")
+        for v in sd.variables:
+            line = f"- `{v['signature']}`"
+            if v.get("doc"):
+                line += f"\n  {v['doc']}"
+            p.append(line + "\n")
+    if sd.functions:
+        p.append("## Functions\n")
+        for fn in sd.functions:
+            static = "static " if fn.get("static") else ""
+            p.append(f"### `{static}func {fn['name']}({fn['params']}) -> {fn['return_type']}`\n")
+            if fn.get("doc"):
+                p.append(fn["doc"] + "\n")
+    return "\n".join(p).rstrip() + "\n"

--- a/src/auto_godot/gdscript_docs.py
+++ b/src/auto_godot/gdscript_docs.py
@@ -18,7 +18,7 @@ _SIGNAL = re.compile(r"^signal\s+(\w+)(?:\(([^)]*)\))?")
 _CONST = re.compile(r"^const\s+(\w+)(?:\s*:\s*\w+)?\s*=\s*(.+)")
 _EXPORT = re.compile(r"^@export(?:_\w+(?:\([^)]*\))?)?\s+var\s+(\w+)\s*(?::\s*([^=]+?))?\s*(?:=\s*(.+))?$")
 _VAR = re.compile(r"^var\s+(\w+)\s*(?::\s*([^=]+?))?\s*(?:=\s*(.+))?$")
-_FUNC = re.compile(r"^(static\s+)?func\s+(\w+)\s*\(([^)]*)\)\s*(?:->\s*(\w+))?")
+_FUNC = re.compile(r"^(static\s+)?func\s+(\w+)\s*\(([^)]*)\)\s*(?:->\s*([\w\[\], ]+))?")
 _ENUM_START = re.compile(r"^enum\s+(\w+)\s*\{(.*)")
 _DOC_COMMENT = re.compile(r"^##\s?(.*)")
 
@@ -64,6 +64,7 @@ class ScriptDoc:
     functions: list[dict[str, Any]] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable dict, omitting empty sections."""
         result: dict[str, Any] = {"path": self.path}
         if self.class_name:
             result["class_name"] = self.class_name
@@ -78,12 +79,8 @@ class ScriptDoc:
         return result
 
 
-def parse_gdscript(text: str, file_path: str = "") -> ScriptDoc:
-    """Parse a GDScript file and extract documentation."""
-    doc = ScriptDoc(path=file_path)
-    lines = text.split("\n")
-
-    # File-level doc comment (## lines before class_name/extends)
+def _extract_file_description(lines: list[str]) -> str:
+    """Extract ## doc comment block before class_name/extends."""
     file_doc: list[str] = []
     for line in lines:
         stripped = line.strip()
@@ -95,66 +92,58 @@ def parse_gdscript(text: str, file_path: str = "") -> ScriptDoc:
                 break
         else:
             break
-    doc.description = "\n".join(file_doc).strip()
+    return "\n".join(file_doc).strip()
 
-    i = 0
-    while i < len(lines):
-        raw = lines[i]
-        s = raw.strip()
-        top = raw == s or raw == ""
 
-        if top and (m := _CLASS_NAME.match(s)):
-            doc.class_name = m.group(1)
-        elif top and (m := _EXTENDS.match(s)):
-            doc.extends = m.group(1)
-        elif top and (m := _ENUM_START.match(s)):
-            vals = _parse_enum_values(lines, i, m.group(2))
-            entry: dict[str, Any] = {"name": m.group(1), "values": vals, "line": i + 1}
-            comment = _collect_doc(lines, i)
-            if comment:
-                entry["doc"] = comment
-            doc.enums.append(entry)
-        elif top and (m := _SIGNAL.match(s)):
-            entry = {"name": m.group(1), "signature": s, "line": i + 1}
-            comment = _collect_doc(lines, i)
-            if comment:
-                entry["doc"] = comment
-            doc.signals.append(entry)
-        elif top and (m := _CONST.match(s)):
-            entry = {"name": m.group(1), "signature": s, "line": i + 1}
-            comment = _collect_doc(lines, i)
-            if comment:
-                entry["doc"] = comment
-            doc.constants.append(entry)
-        elif top and (m := _EXPORT.match(s)):
-            entry = {"name": m.group(1), "signature": s, "line": i + 1}
-            comment = _collect_doc(lines, i)
-            if comment:
-                entry["doc"] = comment
-            doc.exports.append(entry)
-        elif top and (m := _VAR.match(s)):
-            entry = {"name": m.group(1), "signature": s, "line": i + 1}
-            comment = _collect_doc(lines, i)
-            if comment:
-                entry["doc"] = comment
-            doc.variables.append(entry)
-        elif top and (m := _FUNC.match(s)):
-            entry = {
-                "name": m.group(2), "params": m.group(3).strip(),
-                "return_type": m.group(4) or "void", "line": i + 1,
-            }
-            if m.group(1):
-                entry["static"] = True
-            comment = _collect_doc(lines, i)
-            if comment:
-                entry["doc"] = comment
-            doc.functions.append(entry)
-        i += 1
+def _make_entry(name: str, lines: list[str], i: int, **extra: Any) -> dict[str, Any]:
+    """Build a doc entry dict with optional doc comment."""
+    entry: dict[str, Any] = {"name": name, "line": i + 1, **extra}
+    comment = _collect_doc(lines, i)
+    if comment:
+        entry["doc"] = comment
+    return entry
+
+
+def _parse_declaration(doc: ScriptDoc, lines: list[str], i: int, s: str) -> None:
+    """Try to match a single top-level declaration and append to doc."""
+    if m := _CLASS_NAME.match(s):
+        doc.class_name = m.group(1)
+    elif m := _EXTENDS.match(s):
+        doc.extends = m.group(1)
+    elif m := _ENUM_START.match(s):
+        vals = _parse_enum_values(lines, i, m.group(2))
+        doc.enums.append(_make_entry(m.group(1), lines, i, values=vals))
+    elif m := _SIGNAL.match(s):
+        doc.signals.append(_make_entry(m.group(1), lines, i, signature=s))
+    elif m := _CONST.match(s):
+        doc.constants.append(_make_entry(m.group(1), lines, i, signature=s))
+    elif m := _EXPORT.match(s):
+        doc.exports.append(_make_entry(m.group(1), lines, i, signature=s))
+    elif m := _VAR.match(s):
+        doc.variables.append(_make_entry(m.group(1), lines, i, signature=s))
+    elif m := _FUNC.match(s):
+        extra: dict[str, Any] = {
+            "params": m.group(3).strip(),
+            "return_type": (m.group(4) or "void").strip(),
+        }
+        if m.group(1):
+            extra["static"] = True
+        doc.functions.append(_make_entry(m.group(2), lines, i, **extra))
+
+
+def parse_gdscript(text: str, file_path: str = "") -> ScriptDoc:
+    """Parse a GDScript file and extract documentation."""
+    doc = ScriptDoc(path=file_path)
+    lines = text.split("\n")
+    doc.description = _extract_file_description(lines)
+    for i, raw in enumerate(lines):
+        if not raw[:1].isspace():
+            _parse_declaration(doc, lines, i, raw.strip())
     return doc
 
 
-def format_markdown(sd: ScriptDoc) -> str:
-    """Format a ScriptDoc as Markdown."""
+def _md_header(sd: ScriptDoc) -> list[str]:
+    """Render title, extends, and description."""
     p: list[str] = []
     title = sd.class_name or Path(sd.path).stem
     p.append(f"# {title}\n")
@@ -162,6 +151,12 @@ def format_markdown(sd: ScriptDoc) -> str:
         p.append(f"**Extends:** `{sd.extends}`\n")
     if sd.description:
         p.append(sd.description + "\n")
+    return p
+
+
+def _md_sections(sd: ScriptDoc) -> list[str]:
+    """Render signals, enums, constants, exports, variables, functions."""
+    p: list[str] = []
     if sd.signals:
         p.append("## Signals\n")
         for sig in sd.signals:
@@ -174,8 +169,7 @@ def format_markdown(sd: ScriptDoc) -> str:
             p.append(f"### {en['name']}\n")
             if en.get("doc"):
                 p.append(en["doc"] + "\n")
-            for val in en["values"]:
-                p.append(f"- `{val}`")
+            p.extend(f"- `{val}`" for val in en["values"])
             p.append("")
     if sd.constants:
         p.append("## Constants\n")
@@ -206,4 +200,10 @@ def format_markdown(sd: ScriptDoc) -> str:
             p.append(f"### `{static}func {fn['name']}({fn['params']}) -> {fn['return_type']}`\n")
             if fn.get("doc"):
                 p.append(fn["doc"] + "\n")
-    return "\n".join(p).rstrip() + "\n"
+    return p
+
+
+def format_markdown(sd: ScriptDoc) -> str:
+    """Format a ScriptDoc as Markdown."""
+    parts = _md_header(sd) + _md_sections(sd)
+    return "\n".join(parts).rstrip() + "\n"

--- a/tests/unit/test_script_docs.py
+++ b/tests/unit/test_script_docs.py
@@ -1,0 +1,196 @@
+"""Tests for script docs command and GDScript doc parser."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from auto_godot.cli import cli
+from auto_godot.gdscript_docs import format_markdown, parse_gdscript
+
+SAMPLE_SCRIPT = """\
+## A player controller for the game.
+class_name Player
+extends CharacterBody2D
+
+## Emitted when the player dies.
+signal died
+signal health_changed(new_health: int, old_health: int)
+
+enum State { IDLE, RUNNING, JUMPING, FALLING }
+
+## Direction the player is facing.
+enum Direction {
+    LEFT,
+    RIGHT,
+    UP,
+    DOWN,
+}
+
+## Maximum speed in pixels per second.
+const MAX_SPEED: float = 300.0
+
+## Movement speed.
+@export var speed: float = 200.0
+@export_range(0, 100) var health: int = 50
+
+var current_health: int = 100
+## Whether the player can take damage.
+var is_invincible: bool = false
+
+func _ready() -> void:
+    current_health = max_health
+
+## Deal damage to the player.
+func take_damage(amount: int) -> void:
+    if is_invincible:
+        return
+    var old: int = current_health
+    current_health -= amount
+
+func heal(amount: int) -> int:
+    return 0
+
+static func get_default_speed() -> float:
+    return 200.0
+"""
+
+
+class TestParseGdscript:
+    """Verify parser extracts all declaration types."""
+
+    def test_class_metadata(self) -> None:
+        doc = parse_gdscript(SAMPLE_SCRIPT, "player.gd")
+        assert doc.class_name == "Player"
+        assert doc.extends == "CharacterBody2D"
+        assert "player controller" in doc.description
+
+    def test_signals(self) -> None:
+        doc = parse_gdscript(SAMPLE_SCRIPT, "player.gd")
+        assert len(doc.signals) == 2
+        assert doc.signals[0]["name"] == "died"
+        assert "player dies" in doc.signals[0].get("doc", "")
+        assert "health_changed" in doc.signals[1]["signature"]
+
+    def test_enums(self) -> None:
+        doc = parse_gdscript(SAMPLE_SCRIPT, "player.gd")
+        assert len(doc.enums) == 2
+        assert "IDLE" in doc.enums[0]["values"]
+        assert "DOWN" in doc.enums[1]["values"]
+        assert "Direction" in doc.enums[1].get("doc", "")
+
+    def test_constants(self) -> None:
+        doc = parse_gdscript(SAMPLE_SCRIPT, "player.gd")
+        assert len(doc.constants) == 1
+        assert doc.constants[0]["name"] == "MAX_SPEED"
+
+    def test_exports_including_range(self) -> None:
+        doc = parse_gdscript(SAMPLE_SCRIPT, "player.gd")
+        assert len(doc.exports) == 2
+        assert doc.exports[0]["name"] == "speed"
+        assert doc.exports[1]["name"] == "health"
+
+    def test_variables_skip_locals(self) -> None:
+        doc = parse_gdscript(SAMPLE_SCRIPT, "player.gd")
+        names = [v["name"] for v in doc.variables]
+        assert "current_health" in names
+        assert "is_invincible" in names
+        assert "old" not in names  # local var inside take_damage
+
+    def test_functions(self) -> None:
+        doc = parse_gdscript(SAMPLE_SCRIPT, "player.gd")
+        names = [f["name"] for f in doc.functions]
+        assert "_ready" in names
+        assert "take_damage" in names
+        assert "heal" in names
+        heal = next(f for f in doc.functions if f["name"] == "heal")
+        assert heal["return_type"] == "int"
+
+    def test_static_function(self) -> None:
+        doc = parse_gdscript(SAMPLE_SCRIPT, "player.gd")
+        sf = next(f for f in doc.functions if f["name"] == "get_default_speed")
+        assert sf.get("static") is True
+
+    def test_doc_comments_on_functions(self) -> None:
+        doc = parse_gdscript(SAMPLE_SCRIPT, "player.gd")
+        td = next(f for f in doc.functions if f["name"] == "take_damage")
+        assert "Deal damage" in td.get("doc", "")
+
+
+class TestEdgeCases:
+    def test_empty_script(self) -> None:
+        doc = parse_gdscript("", "e.gd")
+        assert doc.class_name is None
+        assert doc.to_dict() == {"path": "e.gd"}
+
+    def test_extends_only(self) -> None:
+        doc = parse_gdscript("extends Node\n", "m.gd")
+        assert doc.extends == "Node"
+
+    def test_empty_sections_omitted_from_dict(self) -> None:
+        d = parse_gdscript("extends Node\n", "m.gd").to_dict()
+        assert "signals" not in d
+        assert "exports" not in d
+
+
+class TestFormatMarkdown:
+    def test_title_and_extends(self) -> None:
+        md = format_markdown(parse_gdscript(SAMPLE_SCRIPT, "player.gd"))
+        assert md.startswith("# Player\n")
+        assert "**Extends:** `CharacterBody2D`" in md
+
+    def test_all_sections_present(self) -> None:
+        md = format_markdown(parse_gdscript(SAMPLE_SCRIPT, "player.gd"))
+        for section in ("Signals", "Enums", "Constants", "Exported Properties", "Functions"):
+            assert f"## {section}" in md
+
+    def test_filename_title_when_no_class(self) -> None:
+        md = format_markdown(parse_gdscript("extends Node\n", "my_util.gd"))
+        assert md.startswith("# my_util\n")
+
+
+class TestDocsCommand:
+    def test_single_file_human(self, tmp_path: Path) -> None:
+        gd = tmp_path / "test.gd"
+        gd.write_text("extends Node2D\n\nfunc greet() -> void:\n\tpass\n")
+        result = CliRunner().invoke(cli, ["script", "docs", str(gd)])
+        assert result.exit_code == 0
+        assert "greet" in result.output
+
+    def test_single_file_json(self, tmp_path: Path) -> None:
+        gd = tmp_path / "p.gd"
+        gd.write_text("class_name P\nextends Node\nsignal died\nfunc _ready() -> void:\n\tpass\n")
+        result = CliRunner().invoke(cli, ["-j", "script", "docs", str(gd)])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["count"] == 1
+        assert data["scripts"][0]["class_name"] == "P"
+
+    def test_directory_recursive(self, tmp_path: Path) -> None:
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "a.gd").write_text("extends Node\n")
+        (tmp_path / "sub" / "b.gd").write_text("extends Node2D\n")
+        result = CliRunner().invoke(cli, ["-j", "script", "docs", str(tmp_path)])
+        data = json.loads(result.output)
+        assert data["count"] == 2
+
+    def test_output_dir(self, tmp_path: Path) -> None:
+        gd = tmp_path / "player.gd"
+        gd.write_text("class_name Player\nextends Node\n")
+        out = tmp_path / "docs"
+        result = CliRunner().invoke(cli, ["script", "docs", str(gd), "-o", str(out)])
+        assert result.exit_code == 0
+        assert (out / "player.md").exists()
+        assert "# Player" in (out / "player.md").read_text()
+
+    def test_non_gd_rejected(self, tmp_path: Path) -> None:
+        txt = tmp_path / "x.txt"
+        txt.write_text("not gdscript")
+        assert CliRunner().invoke(cli, ["script", "docs", str(txt)]).exit_code != 0
+
+    def test_empty_dir_rejected(self, tmp_path: Path) -> None:
+        d = tmp_path / "empty"
+        d.mkdir()
+        assert CliRunner().invoke(cli, ["script", "docs", str(d)]).exit_code != 0

--- a/tests/unit/test_script_docs.py
+++ b/tests/unit/test_script_docs.py
@@ -119,6 +119,17 @@ class TestParseGdscript:
         assert "Deal damage" in td.get("doc", "")
 
 
+    def test_generic_return_type(self) -> None:
+        text = "func get_items() -> Array[int]:\n\treturn []\n"
+        doc = parse_gdscript(text, "g.gd")
+        assert doc.functions[0]["return_type"] == "Array[int]"
+
+    def test_trailing_whitespace_top_level(self) -> None:
+        text = "extends Node\nvar x: int = 0  \n"
+        doc = parse_gdscript(text, "t.gd")
+        assert len(doc.variables) == 1
+
+
 class TestEdgeCases:
     def test_empty_script(self) -> None:
         doc = parse_gdscript("", "e.gd")
@@ -194,3 +205,16 @@ class TestDocsCommand:
         d = tmp_path / "empty"
         d.mkdir()
         assert CliRunner().invoke(cli, ["script", "docs", str(d)]).exit_code != 0
+
+    def test_duplicate_stem_collision(self, tmp_path: Path) -> None:
+        (tmp_path / "scripts").mkdir()
+        (tmp_path / "addons").mkdir()
+        (tmp_path / "scripts" / "player.gd").write_text("extends Node2D\n")
+        (tmp_path / "addons" / "player.gd").write_text("extends Node\n")
+        out = tmp_path / "docs"
+        result = CliRunner().invoke(
+            cli, ["script", "docs", str(tmp_path), "-o", str(out)]
+        )
+        assert result.exit_code == 0
+        md_files = list(out.glob("*.md"))
+        assert len(md_files) == 2  # no overwrite


### PR DESCRIPTION
## Summary

- Add `auto-godot script docs` command for generating documentation from GDScript files
- Regex-based parser extracts: class_name, extends, ## doc comments, signals, @export vars (including @export_range), functions (with static detection), enums (single and multi-line), and constants
- Outputs Markdown to stdout (default) or JSON (--json); supports `-o` flag for writing .md files to a directory
- Handles single .gd files and recursive directory scanning
- Skips local variables inside function bodies (only documents top-level declarations)

## Test plan

- [x] 21 unit tests covering parser extraction, edge cases, Markdown formatting, and CLI integration
- [x] Tests cover: all declaration types, empty scripts, extends-only scripts, @export_range syntax, local var filtering, JSON output, directory recursion, -o output, error handling (non-.gd files, empty directories)
- [x] Existing test suite (89 script/CLI tests) passes with no regressions

Fixes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)