### PR TITLE
feat: add resource dump command for JSON AST output (#87)

### DIFF
--- a/src/auto_godot/commands/resource.py
+++ b/src/auto_godot/commands/resource.py
@@ -434,3 +434,79 @@ def list_resources(ctx: click.Context, scene_path: str) -> None:
             ),
             ctx,
         )
+
+
+# ---------------------------------------------------------------------------
+# resource dump
+# ---------------------------------------------------------------------------
+
+_TSCN_SECTIONS = ("ext_resources", "sub_resources", "nodes", "connections")
+_TRES_SECTIONS = ("ext_resources", "sub_resources", "properties")
+
+
+@resource.command("dump")
+@click.argument("file", type=click.Path(exists=True))
+@click.option(
+    "--section",
+    type=str,
+    default=None,
+    help="Dump only a specific section (nodes, ext_resources, sub_resources, properties, connections).",
+)
+@click.pass_context
+def dump(ctx: click.Context, file: str, section: str | None) -> None:
+    """Dump parsed structure of a .tscn/.tres file as JSON.
+
+    Always outputs JSON regardless of --json flag. Use --section to
+    filter to a specific part of the parsed file.
+
+    Examples:
+
+      auto-godot resource dump scene.tscn
+
+      auto-godot resource dump scene.tscn --section nodes
+
+      auto-godot resource dump spriteframes.tres --section properties
+    """
+    file_path = Path(file)
+    suffix = file_path.suffix.lower()
+
+    if suffix not in (".tres", ".tscn"):
+        emit_error(
+            ProjectError(
+                message=f"Unsupported file format: {suffix}",
+                code="UNSUPPORTED_FORMAT",
+                fix="resource dump supports .tres and .tscn files",
+            ),
+            ctx,
+        )
+        return
+
+    valid_sections = _TSCN_SECTIONS if suffix == ".tscn" else _TRES_SECTIONS
+    if section is not None and section not in valid_sections:
+        emit_error(
+            ProjectError(
+                message=f"Invalid section '{section}' for {suffix} file",
+                code="INVALID_SECTION",
+                fix=f"Valid sections: {', '.join(valid_sections)}",
+            ),
+            ctx,
+        )
+        return
+
+    try:
+        if suffix == ".tscn":
+            parsed = parse_tscn_file(file_path).to_dict()
+        else:
+            parsed = parse_tres_file(file_path).to_dict()
+
+        output = parsed[section] if section else parsed
+        sys.stdout.write(json.dumps(output, cls=GodotJSONEncoder, indent=2) + "\n")
+    except Exception as exc:
+        emit_error(
+            ProjectError(
+                message=f"Failed to parse {file}: {exc}",
+                code="PARSE_ERROR",
+                fix="Ensure the file is a valid Godot resource or scene file",
+            ),
+            ctx,
+        )

--- a/tests/unit/test_resource_dump.py
+++ b/tests/unit/test_resource_dump.py
@@ -1,0 +1,124 @@
+"""Tests for resource dump command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from auto_godot.cli import cli
+
+FIXTURE_TRES = str(
+    Path(__file__).resolve().parent.parent / "fixtures" / "sample.tres"
+)
+FIXTURE_TSCN = str(
+    Path(__file__).resolve().parent.parent / "fixtures" / "sample.tscn"
+)
+
+
+class TestDumpTres:
+    """Verify resource dump on .tres files."""
+
+    def test_dump_exits_zero(self) -> None:
+        result = CliRunner().invoke(cli, ["resource", "dump", FIXTURE_TRES])
+        assert result.exit_code == 0, result.output
+
+    def test_dump_outputs_valid_json(self) -> None:
+        result = CliRunner().invoke(cli, ["resource", "dump", FIXTURE_TRES])
+        data = json.loads(result.output)
+        assert isinstance(data, dict)
+
+    def test_dump_contains_all_sections(self) -> None:
+        result = CliRunner().invoke(cli, ["resource", "dump", FIXTURE_TRES])
+        data = json.loads(result.output)
+        assert "ext_resources" in data
+        assert "sub_resources" in data
+        assert "properties" in data
+        assert data["type"] == "SpriteFrames"
+
+    def test_dump_section_ext_resources(self) -> None:
+        result = CliRunner().invoke(
+            cli, ["resource", "dump", FIXTURE_TRES, "--section", "ext_resources"]
+        )
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) >= 1
+        assert data[0]["type"] == "Texture2D"
+
+    def test_dump_section_sub_resources(self) -> None:
+        result = CliRunner().invoke(
+            cli, ["resource", "dump", FIXTURE_TRES, "--section", "sub_resources"]
+        )
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) >= 1
+        assert data[0]["type"] == "AtlasTexture"
+
+    def test_dump_section_properties(self) -> None:
+        result = CliRunner().invoke(
+            cli, ["resource", "dump", FIXTURE_TRES, "--section", "properties"]
+        )
+        data = json.loads(result.output)
+        assert isinstance(data, dict)
+        assert "animations" in data
+
+
+class TestDumpTscn:
+    """Verify resource dump on .tscn files."""
+
+    def test_dump_exits_zero(self) -> None:
+        result = CliRunner().invoke(cli, ["resource", "dump", FIXTURE_TSCN])
+        assert result.exit_code == 0, result.output
+
+    def test_dump_contains_scene_sections(self) -> None:
+        result = CliRunner().invoke(cli, ["resource", "dump", FIXTURE_TSCN])
+        data = json.loads(result.output)
+        assert "ext_resources" in data
+        assert "nodes" in data
+        assert "connections" in data
+
+    def test_dump_section_nodes(self) -> None:
+        result = CliRunner().invoke(
+            cli, ["resource", "dump", FIXTURE_TSCN, "--section", "nodes"]
+        )
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        names = [n["name"] for n in data]
+        assert "Player" in names
+        assert "Sprite" in names
+
+    def test_dump_section_connections(self) -> None:
+        result = CliRunner().invoke(
+            cli, ["resource", "dump", FIXTURE_TSCN, "--section", "connections"]
+        )
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) >= 1
+        assert data[0]["signal"] == "body_entered"
+
+
+class TestDumpErrors:
+    """Verify error handling."""
+
+    def test_unsupported_format(self, tmp_path: Path) -> None:
+        txt = tmp_path / "x.txt"
+        txt.write_text("hello")
+        result = CliRunner().invoke(cli, ["resource", "dump", str(txt)])
+        assert result.exit_code != 0
+
+    def test_invalid_section_tscn(self) -> None:
+        result = CliRunner().invoke(
+            cli, ["resource", "dump", FIXTURE_TSCN, "--section", "properties"]
+        )
+        assert result.exit_code != 0
+
+    def test_invalid_section_tres(self) -> None:
+        result = CliRunner().invoke(
+            cli, ["resource", "dump", FIXTURE_TRES, "--section", "nodes"]
+        )
+        assert result.exit_code != 0
+
+    def test_nonexistent_file(self) -> None:
+        result = CliRunner().invoke(cli, ["resource", "dump", "/no/such/file.tscn"])
+        assert result.exit_code != 0


### PR DESCRIPTION
## Summary

- Add `auto-godot resource dump` command for outputting full parsed .tscn/.tres structure as JSON
- Supports `--section` flag to filter output: `nodes`, `ext_resources`, `sub_resources`, `properties`, `connections`
- Validates section names per file type (e.g., `nodes` only valid for .tscn, `properties` only for .tres)
- Always outputs JSON; uses `GodotJSONEncoder` to serialize Godot types (Vector2, Color, etc.)

## Test plan

- [x] 14 unit tests covering .tres dump, .tscn dump, section filtering, and error handling
- [x] Existing resource tests (inspect, create) pass with no regressions (36 total)

Fixes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)