### PR TITLE
feat: add preset inspect and validate commands (#84)

### DIFF
--- a/src/auto_godot/commands/preset.py
+++ b/src/auto_godot/commands/preset.py
@@ -200,32 +200,47 @@ def list_presets(
 
 def _parse_presets(text: str) -> list[dict[str, Any]]:
     """Parse export_presets.cfg into a list of preset dicts."""
+    return [
+        {k: v for k, v in p.items() if k != "options"}
+        for p in _parse_presets_full(text)
+    ]
+
+
+def _parse_presets_full(text: str) -> list[dict[str, Any]]:
+    """Parse export_presets.cfg with all fields and options."""
     import re
     presets: list[dict[str, Any]] = []
     current: dict[str, Any] | None = None
+    in_options = False
 
     for line in text.splitlines():
         # New preset section
-        match = re.match(r'\[preset\.(\d+)\]', line)
+        match = re.match(r"\[preset\.(\d+)\]", line)
         if match:
             if current is not None:
                 presets.append(current)
-            current = {"index": int(match.group(1))}
+            current = {"index": int(match.group(1)), "options": {}}
+            in_options = False
             continue
 
-        # Options subsection (skip)
-        if re.match(r'\[preset\.\d+\.options\]', line):
+        # Options subsection
+        if re.match(r"\[preset\.\d+\.options\]", line):
+            in_options = True
             continue
 
-        # Key=value in current preset
+        # Key=value
         if current is not None and "=" in line:
             key, _, value = line.partition("=")
             key = key.strip()
             value = value.strip().strip('"')
-            if key in ("name", "platform", "export_path"):
-                current[key] = value
+            if in_options:
+                current["options"][key] = value
             elif key == "runnable":
                 current[key] = value == "true"
+            elif key == "dedicated_server":
+                current[key] = value == "true"
+            else:
+                current[key] = value
 
     if current is not None:
         presets.append(current)
@@ -250,3 +265,168 @@ def list_platforms(ctx: click.Context) -> None:
             click.echo(f"  {p['key']:12s} {p['name']:20s} -> {p['export_path']}")
 
     emit(data, _human, ctx)
+
+
+# ---------------------------------------------------------------------------
+# preset inspect
+# ---------------------------------------------------------------------------
+
+
+@preset.command("inspect")
+@click.argument("preset_name")
+@click.option(
+    "--project", "project_path", default=".", type=click.Path(),
+    help="Project directory (default: current directory).",
+)
+@click.pass_context
+def inspect(ctx: click.Context, preset_name: str, project_path: str) -> None:
+    """Inspect a specific export preset by name.
+
+    Shows all configuration fields and options for the named preset.
+
+    Examples:
+
+      auto-godot preset inspect "Windows Desktop"
+
+      auto-godot --json preset inspect "Linux" --project /path/to/project
+    """
+    try:
+        project_dir = Path(project_path)
+        if project_dir.is_file():
+            project_dir = project_dir.parent
+
+        preset_file = project_dir / "export_presets.cfg"
+        if not preset_file.exists():
+            raise ProjectError(
+                message="No export_presets.cfg found",
+                code="NO_PRESETS",
+                fix="Create presets with: auto-godot preset create --platform windows",
+            )
+
+        presets = _parse_presets_full(preset_file.read_text(encoding="utf-8"))
+        match = next((p for p in presets if p.get("name") == preset_name), None)
+
+        if match is None:
+            names = [p.get("name", "(unnamed)") for p in presets]
+            raise ProjectError(
+                message=f"Preset '{preset_name}' not found",
+                code="PRESET_NOT_FOUND",
+                fix=f"Available presets: {', '.join(names)}",
+            )
+
+        def _human(data: dict[str, Any], verbose: bool = False) -> None:
+            click.echo(f"Preset: {data.get('name', '(unnamed)')}")
+            for key, val in data.items():
+                if key == "options":
+                    continue
+                click.echo(f"  {key}: {val}")
+            opts = data.get("options", {})
+            if opts:
+                click.echo(f"  options ({len(opts)}):")
+                for k, v in opts.items():
+                    click.echo(f"    {k} = {v}")
+
+        emit(match, _human, ctx)
+    except ProjectError as exc:
+        emit_error(exc, ctx)
+
+
+# ---------------------------------------------------------------------------
+# preset validate
+# ---------------------------------------------------------------------------
+
+
+@preset.command("validate")
+@click.argument("project_path", default=".", type=click.Path())
+@click.pass_context
+def validate(ctx: click.Context, project_path: str) -> None:
+    """Validate export presets for common issues.
+
+    Checks: duplicate names, missing export paths, unrecognized
+    platforms, and whether export directories exist.
+
+    Examples:
+
+      auto-godot preset validate
+
+      auto-godot --json preset validate /path/to/project
+    """
+    try:
+        project_dir = Path(project_path)
+        if project_dir.is_file():
+            project_dir = project_dir.parent
+
+        preset_file = project_dir / "export_presets.cfg"
+        if not preset_file.exists():
+            raise ProjectError(
+                message="No export_presets.cfg found",
+                code="NO_PRESETS",
+                fix="Create presets with: auto-godot preset create --platform windows",
+            )
+
+        presets = _parse_presets_full(preset_file.read_text(encoding="utf-8"))
+        warnings: list[dict[str, str]] = []
+        known_platforms = {info["platform"] for info in _PLATFORMS.values()}
+
+        # Check for duplicate names
+        names: list[str] = []
+        for p in presets:
+            name = p.get("name", "")
+            if name in names:
+                warnings.append({
+                    "preset": name,
+                    "issue": "duplicate_name",
+                    "message": f"Duplicate preset name: '{name}'",
+                })
+            names.append(name)
+
+        for p in presets:
+            name = p.get("name", f"preset.{p.get('index', '?')}")
+
+            # Missing export path
+            if not p.get("export_path"):
+                warnings.append({
+                    "preset": name,
+                    "issue": "missing_export_path",
+                    "message": "No export_path configured",
+                })
+
+            # Check platform
+            platform = p.get("platform", "")
+            if platform and platform not in known_platforms:
+                warnings.append({
+                    "preset": name,
+                    "issue": "unknown_platform",
+                    "message": f"Unrecognized platform: '{platform}'",
+                })
+
+            # Check export directory exists
+            export_path = p.get("export_path", "")
+            if export_path:
+                full = project_dir / export_path
+                if not full.parent.exists():
+                    warnings.append({
+                        "preset": name,
+                        "issue": "missing_export_dir",
+                        "message": f"Export directory does not exist: {full.parent}",
+                    })
+
+        data = {
+            "valid": len(warnings) == 0,
+            "preset_count": len(presets),
+            "warning_count": len(warnings),
+            "warnings": warnings,
+        }
+
+        def _human(data: dict[str, Any], verbose: bool = False) -> None:
+            count = data["preset_count"]
+            if data["valid"]:
+                click.echo(f"All {count} preset(s) valid.")
+                return
+            click.echo(f"Found {data['warning_count']} issue(s) in {count} preset(s):")
+            for w in data["warnings"]:
+                click.echo(f"  [{w['preset']}] {w['message']}")
+
+        emit(data, _human, ctx)
+    except ProjectError as exc:
+        emit_error(exc, ctx)

--- a/src/auto_godot/commands/preset.py
+++ b/src/auto_godot/commands/preset.py
@@ -272,6 +272,49 @@ def list_platforms(ctx: click.Context) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _load_presets_file(project_path: str) -> tuple[Path, list[dict[str, Any]]]:
+    """Resolve project dir, read export_presets.cfg, return (dir, presets)."""
+    project_dir = Path(project_path)
+    if project_dir.is_file():
+        project_dir = project_dir.parent
+    preset_file = project_dir / "export_presets.cfg"
+    if not preset_file.exists():
+        raise ProjectError(
+            message="No export_presets.cfg found",
+            code="NO_PRESETS",
+            fix="Create presets with: auto-godot preset create --platform windows",
+        )
+    presets = _parse_presets_full(preset_file.read_text(encoding="utf-8"))
+    return project_dir, presets
+
+
+def _find_preset(presets: list[dict[str, Any]], name: str) -> dict[str, Any]:
+    """Find a preset by name, raising ProjectError if not found."""
+    match = next((p for p in presets if p.get("name") == name), None)
+    if match is None:
+        names = [p.get("name", "(unnamed)") for p in presets]
+        raise ProjectError(
+            message=f"Preset '{name}' not found",
+            code="PRESET_NOT_FOUND",
+            fix=f"Available presets: {', '.join(names)}",
+        )
+    return match
+
+
+def _display_inspect(data: dict[str, Any], verbose: bool = False) -> None:
+    """Human-readable output for preset inspect."""
+    click.echo(f"Preset: {data.get('name', '(unnamed)')}")
+    for key, val in data.items():
+        if key == "options":
+            continue
+        click.echo(f"  {key}: {val}")
+    opts = data.get("options", {})
+    if opts:
+        click.echo(f"  options ({len(opts)}):")
+        for k, v in opts.items():
+            click.echo(f"    {k} = {v}")
+
+
 @preset.command("inspect")
 @click.argument("preset_name")
 @click.option(
@@ -291,42 +334,9 @@ def inspect(ctx: click.Context, preset_name: str, project_path: str) -> None:
       auto-godot --json preset inspect "Linux" --project /path/to/project
     """
     try:
-        project_dir = Path(project_path)
-        if project_dir.is_file():
-            project_dir = project_dir.parent
-
-        preset_file = project_dir / "export_presets.cfg"
-        if not preset_file.exists():
-            raise ProjectError(
-                message="No export_presets.cfg found",
-                code="NO_PRESETS",
-                fix="Create presets with: auto-godot preset create --platform windows",
-            )
-
-        presets = _parse_presets_full(preset_file.read_text(encoding="utf-8"))
-        match = next((p for p in presets if p.get("name") == preset_name), None)
-
-        if match is None:
-            names = [p.get("name", "(unnamed)") for p in presets]
-            raise ProjectError(
-                message=f"Preset '{preset_name}' not found",
-                code="PRESET_NOT_FOUND",
-                fix=f"Available presets: {', '.join(names)}",
-            )
-
-        def _human(data: dict[str, Any], verbose: bool = False) -> None:
-            click.echo(f"Preset: {data.get('name', '(unnamed)')}")
-            for key, val in data.items():
-                if key == "options":
-                    continue
-                click.echo(f"  {key}: {val}")
-            opts = data.get("options", {})
-            if opts:
-                click.echo(f"  options ({len(opts)}):")
-                for k, v in opts.items():
-                    click.echo(f"    {k} = {v}")
-
-        emit(match, _human, ctx)
+        _, presets = _load_presets_file(project_path)
+        match = _find_preset(presets, preset_name)
+        emit(match, _display_inspect, ctx)
     except ProjectError as exc:
         emit_error(exc, ctx)
 
@@ -334,6 +344,58 @@ def inspect(ctx: click.Context, preset_name: str, project_path: str) -> None:
 # ---------------------------------------------------------------------------
 # preset validate
 # ---------------------------------------------------------------------------
+
+
+def _check_duplicate_names(presets: list[dict[str, Any]]) -> list[dict[str, str]]:
+    """Check for duplicate preset names."""
+    warnings: list[dict[str, str]] = []
+    seen: list[str] = []
+    for p in presets:
+        name = p.get("name", "")
+        if name in seen:
+            warnings.append({
+                "preset": name, "issue": "duplicate_name",
+                "message": f"Duplicate preset name: '{name}'",
+            })
+        seen.append(name)
+    return warnings
+
+
+def _check_preset_fields(
+    p: dict[str, Any], project_dir: Path, known_platforms: set[str],
+) -> list[dict[str, str]]:
+    """Validate a single preset's fields."""
+    warnings: list[dict[str, str]] = []
+    name = p.get("name", f"preset.{p.get('index', '?')}")
+    if not p.get("export_path"):
+        warnings.append({
+            "preset": name, "issue": "missing_export_path",
+            "message": "No export_path configured",
+        })
+    platform = p.get("platform", "")
+    if platform and platform not in known_platforms:
+        warnings.append({
+            "preset": name, "issue": "unknown_platform",
+            "message": f"Unrecognized platform: '{platform}'",
+        })
+    export_path = p.get("export_path", "")
+    if export_path and not (project_dir / export_path).parent.exists():
+        warnings.append({
+            "preset": name, "issue": "missing_export_dir",
+            "message": f"Export directory does not exist: {(project_dir / export_path).parent}",
+        })
+    return warnings
+
+
+def _display_validate(data: dict[str, Any], verbose: bool = False) -> None:
+    """Human-readable output for preset validate."""
+    count = data["preset_count"]
+    if data["valid"]:
+        click.echo(f"All {count} preset(s) valid.")
+        return
+    click.echo(f"Found {data['warning_count']} issue(s) in {count} preset(s):")
+    for w in data["warnings"]:
+        click.echo(f"  [{w['preset']}] {w['message']}")
 
 
 @preset.command("validate")
@@ -352,81 +414,17 @@ def validate(ctx: click.Context, project_path: str) -> None:
       auto-godot --json preset validate /path/to/project
     """
     try:
-        project_dir = Path(project_path)
-        if project_dir.is_file():
-            project_dir = project_dir.parent
-
-        preset_file = project_dir / "export_presets.cfg"
-        if not preset_file.exists():
-            raise ProjectError(
-                message="No export_presets.cfg found",
-                code="NO_PRESETS",
-                fix="Create presets with: auto-godot preset create --platform windows",
-            )
-
-        presets = _parse_presets_full(preset_file.read_text(encoding="utf-8"))
-        warnings: list[dict[str, str]] = []
+        project_dir, presets = _load_presets_file(project_path)
         known_platforms = {info["platform"] for info in _PLATFORMS.values()}
-
-        # Check for duplicate names
-        names: list[str] = []
+        warnings = _check_duplicate_names(presets)
         for p in presets:
-            name = p.get("name", "")
-            if name in names:
-                warnings.append({
-                    "preset": name,
-                    "issue": "duplicate_name",
-                    "message": f"Duplicate preset name: '{name}'",
-                })
-            names.append(name)
-
-        for p in presets:
-            name = p.get("name", f"preset.{p.get('index', '?')}")
-
-            # Missing export path
-            if not p.get("export_path"):
-                warnings.append({
-                    "preset": name,
-                    "issue": "missing_export_path",
-                    "message": "No export_path configured",
-                })
-
-            # Check platform
-            platform = p.get("platform", "")
-            if platform and platform not in known_platforms:
-                warnings.append({
-                    "preset": name,
-                    "issue": "unknown_platform",
-                    "message": f"Unrecognized platform: '{platform}'",
-                })
-
-            # Check export directory exists
-            export_path = p.get("export_path", "")
-            if export_path:
-                full = project_dir / export_path
-                if not full.parent.exists():
-                    warnings.append({
-                        "preset": name,
-                        "issue": "missing_export_dir",
-                        "message": f"Export directory does not exist: {full.parent}",
-                    })
-
+            warnings.extend(_check_preset_fields(p, project_dir, known_platforms))
         data = {
             "valid": len(warnings) == 0,
             "preset_count": len(presets),
             "warning_count": len(warnings),
             "warnings": warnings,
         }
-
-        def _human(data: dict[str, Any], verbose: bool = False) -> None:
-            count = data["preset_count"]
-            if data["valid"]:
-                click.echo(f"All {count} preset(s) valid.")
-                return
-            click.echo(f"Found {data['warning_count']} issue(s) in {count} preset(s):")
-            for w in data["warnings"]:
-                click.echo(f"  [{w['preset']}] {w['message']}")
-
-        emit(data, _human, ctx)
+        emit(data, _display_validate, ctx)
     except ProjectError as exc:
         emit_error(exc, ctx)

--- a/tests/unit/test_preset_inspect_validate.py
+++ b/tests/unit/test_preset_inspect_validate.py
@@ -122,7 +122,9 @@ class TestPresetValidate:
         result = CliRunner().invoke(
             cli, ["-j", "preset", "validate", str(tmp_path)]
         )
+        assert result.exit_code == 0  # warnings are informational, not errors
         data = json.loads(result.output)
+        assert data["valid"] is False
         issues = [w["issue"] for w in data["warnings"]]
         assert "duplicate_name" in issues
 
@@ -132,7 +134,9 @@ class TestPresetValidate:
         result = CliRunner().invoke(
             cli, ["-j", "preset", "validate", str(tmp_path)]
         )
+        assert result.exit_code == 0
         data = json.loads(result.output)
+        assert data["valid"] is False
         issues = [w["issue"] for w in data["warnings"]]
         assert "missing_export_path" in issues
 
@@ -142,7 +146,9 @@ class TestPresetValidate:
         result = CliRunner().invoke(
             cli, ["-j", "preset", "validate", str(tmp_path)]
         )
+        assert result.exit_code == 0
         data = json.loads(result.output)
+        assert data["valid"] is False
         issues = [w["issue"] for w in data["warnings"]]
         assert "unknown_platform" in issues
 
@@ -151,7 +157,9 @@ class TestPresetValidate:
         result = CliRunner().invoke(
             cli, ["-j", "preset", "validate", str(tmp_path)]
         )
+        assert result.exit_code == 0
         data = json.loads(result.output)
+        assert data["valid"] is False
         issues = [w["issue"] for w in data["warnings"]]
         assert "missing_export_dir" in issues
 

--- a/tests/unit/test_preset_inspect_validate.py
+++ b/tests/unit/test_preset_inspect_validate.py
@@ -1,0 +1,162 @@
+"""Tests for preset inspect and validate commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from auto_godot.cli import cli
+
+SAMPLE_PRESETS = """\
+[preset.0]
+
+name="Windows Desktop"
+platform="Windows Desktop"
+runnable=true
+dedicated_server=false
+custom_features=""
+export_path="export/game.exe"
+encrypt_pck=false
+script_export_mode=2
+
+[preset.0.options]
+
+binary_format/embed_pck=true
+texture_format/s3tc_bptc=true
+
+[preset.1]
+
+name="Web"
+platform="Web"
+runnable=false
+dedicated_server=false
+custom_features=""
+export_path="export/index.html"
+encrypt_pck=false
+
+[preset.1.options]
+
+html/export_icon=true
+"""
+
+
+def _create_presets(tmp_path: Path, content: str = SAMPLE_PRESETS) -> Path:
+    """Write a preset file and return the project directory."""
+    (tmp_path / "export_presets.cfg").write_text(content, encoding="utf-8")
+    return tmp_path
+
+
+class TestPresetInspect:
+    def test_inspect_by_name(self, tmp_path: Path) -> None:
+        _create_presets(tmp_path)
+        result = CliRunner().invoke(
+            cli, ["preset", "inspect", "Windows Desktop", "--project", str(tmp_path)]
+        )
+        assert result.exit_code == 0
+        assert "Windows Desktop" in result.output
+
+    def test_inspect_json(self, tmp_path: Path) -> None:
+        _create_presets(tmp_path)
+        result = CliRunner().invoke(
+            cli, ["-j", "preset", "inspect", "Windows Desktop", "--project", str(tmp_path)]
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["name"] == "Windows Desktop"
+        assert data["platform"] == "Windows Desktop"
+        assert data["runnable"] is True
+
+    def test_inspect_includes_options(self, tmp_path: Path) -> None:
+        _create_presets(tmp_path)
+        result = CliRunner().invoke(
+            cli, ["-j", "preset", "inspect", "Windows Desktop", "--project", str(tmp_path)]
+        )
+        data = json.loads(result.output)
+        assert "options" in data
+        assert data["options"]["binary_format/embed_pck"] == "true"
+
+    def test_inspect_not_found(self, tmp_path: Path) -> None:
+        _create_presets(tmp_path)
+        result = CliRunner().invoke(
+            cli, ["preset", "inspect", "Nonexistent", "--project", str(tmp_path)]
+        )
+        assert result.exit_code != 0
+
+    def test_inspect_no_presets_file(self, tmp_path: Path) -> None:
+        result = CliRunner().invoke(
+            cli, ["preset", "inspect", "Windows Desktop", "--project", str(tmp_path)]
+        )
+        assert result.exit_code != 0
+
+
+class TestPresetValidate:
+    def test_valid_presets(self, tmp_path: Path) -> None:
+        _create_presets(tmp_path)
+        (tmp_path / "export").mkdir()  # Create export dir
+        result = CliRunner().invoke(
+            cli, ["preset", "validate", str(tmp_path)]
+        )
+        assert result.exit_code == 0
+        assert "valid" in result.output.lower()
+
+    def test_valid_json(self, tmp_path: Path) -> None:
+        _create_presets(tmp_path)
+        (tmp_path / "export").mkdir()
+        result = CliRunner().invoke(
+            cli, ["-j", "preset", "validate", str(tmp_path)]
+        )
+        data = json.loads(result.output)
+        assert data["valid"] is True
+        assert data["preset_count"] == 2
+
+    def test_duplicate_name_warning(self, tmp_path: Path) -> None:
+        content = (
+            '[preset.0]\nname="Dup"\nplatform="Windows Desktop"\nexport_path="a.exe"\n'
+            '[preset.0.options]\n'
+            '[preset.1]\nname="Dup"\nplatform="Linux"\nexport_path="a.x86"\n'
+            '[preset.1.options]\n'
+        )
+        _create_presets(tmp_path, content)
+        result = CliRunner().invoke(
+            cli, ["-j", "preset", "validate", str(tmp_path)]
+        )
+        data = json.loads(result.output)
+        issues = [w["issue"] for w in data["warnings"]]
+        assert "duplicate_name" in issues
+
+    def test_missing_export_path_warning(self, tmp_path: Path) -> None:
+        content = '[preset.0]\nname="Bad"\nplatform="Windows Desktop"\n[preset.0.options]\n'
+        _create_presets(tmp_path, content)
+        result = CliRunner().invoke(
+            cli, ["-j", "preset", "validate", str(tmp_path)]
+        )
+        data = json.loads(result.output)
+        issues = [w["issue"] for w in data["warnings"]]
+        assert "missing_export_path" in issues
+
+    def test_unknown_platform_warning(self, tmp_path: Path) -> None:
+        content = '[preset.0]\nname="T"\nplatform="PS5"\nexport_path="a.bin"\n[preset.0.options]\n'
+        _create_presets(tmp_path, content)
+        result = CliRunner().invoke(
+            cli, ["-j", "preset", "validate", str(tmp_path)]
+        )
+        data = json.loads(result.output)
+        issues = [w["issue"] for w in data["warnings"]]
+        assert "unknown_platform" in issues
+
+    def test_missing_export_dir_warning(self, tmp_path: Path) -> None:
+        _create_presets(tmp_path)  # No export/ dir created
+        result = CliRunner().invoke(
+            cli, ["-j", "preset", "validate", str(tmp_path)]
+        )
+        data = json.loads(result.output)
+        issues = [w["issue"] for w in data["warnings"]]
+        assert "missing_export_dir" in issues
+
+    def test_no_presets_file(self, tmp_path: Path) -> None:
+        result = CliRunner().invoke(
+            cli, ["preset", "validate", str(tmp_path)]
+        )
+        assert result.exit_code != 0


### PR DESCRIPTION
## Summary

- Add `auto-godot preset inspect <name>` to display all fields and options for a named export preset
- Add `auto-godot preset validate` to check presets for: duplicate names, missing export paths, unrecognized platforms, missing export directories
- Enhanced preset parser to capture all key-value pairs and [preset.N.options] sections
- Existing `preset list` and `preset create` behavior unchanged (backward compatible)

## Test plan

- [x] 12 new tests: inspect (by name, JSON, options, not found, no file), validate (valid, JSON, duplicate name, missing path, unknown platform, missing dir, no file)
- [x] All 13 existing preset tests pass with no regressions (25 total)

Fixes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)