### PR TITLE
feat: add TexturePacker import support (#86)

### DIFF
--- a/src/auto_godot/commands/sprite.py
+++ b/src/auto_godot/commands/sprite.py
@@ -319,6 +319,119 @@ def _emit_result(
     emit(data, _print_import_result, ctx)
 
 
+# ---------------------------------------------------------------------------
+# sprite import-texturepacker
+# ---------------------------------------------------------------------------
+
+
+@sprite.command("import-texturepacker")
+@click.argument("json_file", type=click.Path(exists=True))
+@click.option(
+    "-o", "--output", type=click.Path(), default=None,
+    help="Output .tres path. Default: replaces .json with .tres.",
+)
+@click.option(
+    "--res-path", type=str, default=None,
+    help="Godot res:// path for the atlas texture.",
+)
+@click.option(
+    "--fps", type=float, default=10.0,
+    help="Animation FPS (default: 10). TexturePacker has no duration info.",
+)
+@click.pass_context
+def import_texturepacker(
+    ctx: click.Context,
+    json_file: str,
+    output: str | None,
+    res_path: str | None,
+    fps: float,
+) -> None:
+    """Convert TexturePacker JSON atlas exports to Godot SpriteFrames .tres.
+
+    Reads a TexturePacker JSON metadata file and generates a SpriteFrames
+    resource. Frames are grouped into animations by filename prefix
+    (strips trailing numbers: idle_0, idle_1 -> animation "idle").
+
+    Examples:
+
+      auto-godot sprite import-texturepacker atlas.json
+
+      auto-godot sprite import-texturepacker atlas.json -o sprites/atlas.tres --fps 12
+    """
+    from auto_godot.formats.texturepacker import (
+        group_frames_by_animation,
+        parse_texturepacker_json,
+    )
+    from auto_godot.formats.tres import SubResource
+
+    try:
+        json_path = Path(json_file)
+        frames, meta_image = parse_texturepacker_json(json_path, fps=fps)
+
+        if not frames:
+            emit_error(
+                AutoGodotError(
+                    message="TexturePacker JSON contains zero frames",
+                    code="TEXTUREPACKER_NO_FRAMES",
+                    fix="Check the TexturePacker export contains sprite data",
+                ),
+                ctx,
+            )
+            return
+
+        image_res_path = _resolve_image_path(res_path, meta_image, output)
+
+        ext = ExtResource(
+            type="Texture2D",
+            path=image_res_path,
+            id=generate_resource_id("Texture2D"),
+            uid=None,
+        )
+
+        groups = group_frames_by_animation(frames)
+        all_sub_resources: list[SubResource] = []
+        animations: list[dict[str, Any]] = []
+
+        for anim_name, anim_frames in groups.items():
+            tag = AsepriteTag(
+                name=anim_name,
+                from_frame=0,
+                to_frame=len(anim_frames) - 1,
+                direction=AniDirection.FORWARD,
+                repeat=0,
+            )
+            tag_subs, anim_dict = build_animation_for_tag(
+                tag, anim_frames, ext,
+            )
+            all_sub_resources.extend(tag_subs)
+            animations.append(anim_dict)
+
+        resource = GdResource(
+            type="SpriteFrames", format=3,
+            uid=uid_to_text(generate_uid()),
+            load_steps=None,
+            ext_resources=[ext],
+            sub_resources=all_sub_resources,
+            resource_properties={"animations": animations},
+        )
+
+        output_path = _resolve_output_path(output, json_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        serialize_tres_file(resource, output_path)
+
+        data: dict[str, Any] = {
+            "output_path": str(output_path),
+            "animation_count": len(animations),
+            "frame_count": len(all_sub_resources),
+            "image_path": image_res_path,
+            "animations": [str(a.get("name", "")) for a in animations],
+            "warnings": [],
+        }
+        emit(data, _print_import_result, ctx)
+    except (ValidationError, AutoGodotError) as exc:
+        emit_error(exc, ctx)
+
+
 @sprite.command("split")
 @click.argument("image_file", type=click.Path(exists=False))
 @click.option(

--- a/src/auto_godot/formats/texturepacker.py
+++ b/src/auto_godot/formats/texturepacker.py
@@ -1,0 +1,106 @@
+"""TexturePacker JSON metadata parser.
+
+Parses TexturePacker JSON exports (both hash and array frame formats)
+and converts to AsepriteFrame objects for reuse with the SpriteFrames
+builder.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from auto_godot.errors import ValidationError
+from auto_godot.formats.aseprite import AsepriteFrame, FrameRect
+
+
+def _parse_rect(d: dict[str, int]) -> FrameRect:
+    return FrameRect(x=d["x"], y=d["y"], w=d["w"], h=d["h"])
+
+
+def _parse_frame(name: str, data: dict[str, Any], duration_ms: int) -> AsepriteFrame:
+    """Convert a single TexturePacker frame entry to AsepriteFrame."""
+    frame = _parse_rect(data["frame"])
+    sss = _parse_rect(data.get("spriteSourceSize", data["frame"]))
+    src = data.get("sourceSize", {"w": frame.w, "h": frame.h})
+    return AsepriteFrame(
+        filename=name,
+        frame=frame,
+        trimmed=data.get("trimmed", False),
+        sprite_source_size=sss,
+        source_size=(src["w"], src["h"]),
+        duration=duration_ms,
+    )
+
+
+def parse_texturepacker_json(
+    path: Path, fps: float = 10.0,
+) -> tuple[list[AsepriteFrame], str]:
+    """Parse a TexturePacker JSON file.
+
+    Returns (frames sorted by filename, image filename from meta).
+    Supports both hash and array frame formats.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+        data = json.loads(text)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationError(
+            message=f"Failed to read TexturePacker JSON: {exc}",
+            code="TEXTUREPACKER_READ_ERROR",
+            fix="Check the file is valid TexturePacker JSON",
+        ) from exc
+
+    raw_frames = data.get("frames")
+    if raw_frames is None:
+        raise ValidationError(
+            message="No 'frames' key in TexturePacker JSON",
+            code="TEXTUREPACKER_NO_FRAMES",
+            fix="Export from TexturePacker with JSON data format",
+        )
+
+    duration_ms = max(1, int(1000.0 / fps))
+    frames: list[AsepriteFrame] = []
+
+    if isinstance(raw_frames, dict):
+        for name, fdata in raw_frames.items():
+            frames.append(_parse_frame(name, fdata, duration_ms))
+    elif isinstance(raw_frames, list):
+        for fdata in raw_frames:
+            name = fdata.get("filename", f"frame_{len(frames)}")
+            frames.append(_parse_frame(name, fdata, duration_ms))
+    else:
+        raise ValidationError(
+            message="'frames' must be an object or array",
+            code="TEXTUREPACKER_INVALID_FRAMES",
+            fix="Re-export from TexturePacker",
+        )
+
+    frames.sort(key=lambda f: f.filename)
+
+    meta = data.get("meta", {})
+    image = meta.get("image", path.with_suffix(".png").name)
+
+    return frames, image
+
+
+# Pattern to strip trailing frame numbers: "idle_0.png" -> "idle"
+_TRAILING_NUM = re.compile(r"[_ -]?\d+$")
+
+
+def group_frames_by_animation(
+    frames: list[AsepriteFrame],
+) -> dict[str, list[AsepriteFrame]]:
+    """Group frames into animations by filename prefix.
+
+    Strips file extension and trailing numbers/separators to derive
+    animation names. E.g., "idle_0.png", "idle_1.png" -> "idle".
+    """
+    groups: dict[str, list[AsepriteFrame]] = {}
+    for frame in frames:
+        stem = Path(frame.filename).stem
+        name = _TRAILING_NUM.sub("", stem) or stem
+        groups.setdefault(name, []).append(frame)
+    return groups

--- a/tests/fixtures/texturepacker_sample.json
+++ b/tests/fixtures/texturepacker_sample.json
@@ -1,0 +1,39 @@
+{
+  "frames": {
+    "idle_0.png": {
+      "frame": {"x": 0, "y": 0, "w": 32, "h": 32},
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": {"x": 0, "y": 0, "w": 32, "h": 32},
+      "sourceSize": {"w": 32, "h": 32}
+    },
+    "idle_1.png": {
+      "frame": {"x": 32, "y": 0, "w": 32, "h": 32},
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": {"x": 0, "y": 0, "w": 32, "h": 32},
+      "sourceSize": {"w": 32, "h": 32}
+    },
+    "run_0.png": {
+      "frame": {"x": 64, "y": 0, "w": 32, "h": 32},
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": {"x": 0, "y": 0, "w": 32, "h": 32},
+      "sourceSize": {"w": 32, "h": 32}
+    },
+    "run_1.png": {
+      "frame": {"x": 96, "y": 0, "w": 32, "h": 32},
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": {"x": 0, "y": 0, "w": 32, "h": 32},
+      "sourceSize": {"w": 32, "h": 32}
+    }
+  },
+  "meta": {
+    "app": "https://www.codeandweb.com/texturepacker",
+    "image": "atlas.png",
+    "format": "RGBA8888",
+    "size": {"w": 128, "h": 32},
+    "scale": "1"
+  }
+}

--- a/tests/unit/test_texturepacker_import.py
+++ b/tests/unit/test_texturepacker_import.py
@@ -1,0 +1,148 @@
+"""Tests for TexturePacker import command and parser."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from auto_godot.cli import cli
+from auto_godot.formats.texturepacker import (
+    group_frames_by_animation,
+    parse_texturepacker_json,
+)
+
+FIXTURE = Path(__file__).resolve().parent.parent / "fixtures" / "texturepacker_sample.json"
+
+
+class TestParseTexturePackerJson:
+    def test_parses_hash_format(self) -> None:
+        frames, image = parse_texturepacker_json(FIXTURE)
+        assert len(frames) == 4
+        assert image == "atlas.png"
+
+    def test_frames_sorted_by_filename(self) -> None:
+        frames, _ = parse_texturepacker_json(FIXTURE)
+        names = [f.filename for f in frames]
+        assert names == sorted(names)
+
+    def test_frame_regions(self) -> None:
+        frames, _ = parse_texturepacker_json(FIXTURE)
+        first = frames[0]  # idle_0.png (sorted first)
+        assert first.frame.w == 32
+        assert first.frame.h == 32
+
+    def test_fps_affects_duration(self) -> None:
+        frames_10, _ = parse_texturepacker_json(FIXTURE, fps=10.0)
+        frames_20, _ = parse_texturepacker_json(FIXTURE, fps=20.0)
+        assert frames_10[0].duration == 100  # 1000/10
+        assert frames_20[0].duration == 50   # 1000/20
+
+    def test_array_format(self, tmp_path: Path) -> None:
+        data = {
+            "frames": [
+                {"filename": "a.png", "frame": {"x": 0, "y": 0, "w": 16, "h": 16},
+                 "trimmed": False, "spriteSourceSize": {"x": 0, "y": 0, "w": 16, "h": 16},
+                 "sourceSize": {"w": 16, "h": 16}},
+            ],
+            "meta": {"image": "sheet.png"},
+        }
+        f = tmp_path / "tp.json"
+        f.write_text(json.dumps(data))
+        frames, image = parse_texturepacker_json(f)
+        assert len(frames) == 1
+        assert image == "sheet.png"
+
+    def test_invalid_json_error(self, tmp_path: Path) -> None:
+        f = tmp_path / "bad.json"
+        f.write_text("not json")
+        import pytest
+        from auto_godot.errors import ValidationError
+        with pytest.raises(ValidationError):
+            parse_texturepacker_json(f)
+
+    def test_no_frames_key_error(self, tmp_path: Path) -> None:
+        f = tmp_path / "empty.json"
+        f.write_text('{"meta": {}}')
+        import pytest
+        from auto_godot.errors import ValidationError
+        with pytest.raises(ValidationError, match="No 'frames'"):
+            parse_texturepacker_json(f)
+
+
+class TestGroupFramesByAnimation:
+    def test_groups_by_prefix(self) -> None:
+        frames, _ = parse_texturepacker_json(FIXTURE)
+        groups = group_frames_by_animation(frames)
+        assert "idle" in groups
+        assert "run" in groups
+        assert len(groups["idle"]) == 2
+        assert len(groups["run"]) == 2
+
+    def test_single_frame_no_number(self, tmp_path: Path) -> None:
+        data = {
+            "frames": {"logo.png": {
+                "frame": {"x": 0, "y": 0, "w": 64, "h": 64},
+                "trimmed": False,
+                "spriteSourceSize": {"x": 0, "y": 0, "w": 64, "h": 64},
+                "sourceSize": {"w": 64, "h": 64},
+            }},
+            "meta": {"image": "sheet.png"},
+        }
+        f = tmp_path / "tp.json"
+        f.write_text(json.dumps(data))
+        frames, _ = parse_texturepacker_json(f)
+        groups = group_frames_by_animation(frames)
+        assert "logo" in groups
+
+
+class TestImportTexturePackerCommand:
+    def test_basic_import(self, tmp_path: Path) -> None:
+        out = tmp_path / "result.tres"
+        result = CliRunner().invoke(cli, [
+            "sprite", "import-texturepacker", str(FIXTURE), "-o", str(out),
+        ])
+        assert result.exit_code == 0, result.output
+        assert out.exists()
+        content = out.read_text()
+        assert "SpriteFrames" in content
+        assert "AtlasTexture" in content
+
+    def test_json_output(self, tmp_path: Path) -> None:
+        out = tmp_path / "result.tres"
+        result = CliRunner().invoke(cli, [
+            "-j", "sprite", "import-texturepacker", str(FIXTURE), "-o", str(out),
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["animation_count"] == 2
+        assert data["frame_count"] == 4
+
+    def test_custom_fps(self, tmp_path: Path) -> None:
+        out = tmp_path / "result.tres"
+        result = CliRunner().invoke(cli, [
+            "-j", "sprite", "import-texturepacker", str(FIXTURE),
+            "-o", str(out), "--fps", "12",
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["animation_count"] == 2
+
+    def test_default_output_path(self) -> None:
+        result = CliRunner().invoke(cli, [
+            "-j", "sprite", "import-texturepacker", str(FIXTURE),
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["output_path"].endswith(".tres")
+
+    def test_generated_tres_valid(self, tmp_path: Path) -> None:
+        out = tmp_path / "result.tres"
+        CliRunner().invoke(cli, [
+            "sprite", "import-texturepacker", str(FIXTURE), "-o", str(out),
+        ])
+        content = out.read_text()
+        assert "[gd_resource" in content
+        assert "atlas = ExtResource(" in content
+        assert "region = Rect2(" in content


### PR DESCRIPTION
## Summary

- Add `auto-godot sprite import-texturepacker` command for converting TexturePacker JSON atlas exports to Godot SpriteFrames .tres
- Frames auto-grouped into animations by filename prefix (strips trailing numbers: `idle_0`, `idle_1` -> animation "idle")
- Supports both hash and array TexturePacker JSON formats
- Custom animation FPS via `--fps` flag (TexturePacker has no duration data)
- Reuses existing AtlasTexture builder from the Aseprite pipeline (no code duplication)
- New TexturePacker JSON parser module at `formats/texturepacker.py`

## Test plan

- [x] 14 tests: parser (hash/array formats, frame regions, FPS, error handling), animation grouping, CLI (basic import, JSON output, custom FPS, .tres validation)
- [x] All 96 existing sprite tests pass with no regressions

Fixes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)