### PR TITLE
fix: use Godot 4 dictionary format for animation value track keys (#92)

### DIFF
--- a/src/auto_godot/commands/animation.py
+++ b/src/auto_godot/commands/animation.py
@@ -42,16 +42,21 @@ def _build_track_properties(
     interp_mode = _INTERP_MODES.get(interp, 1)
     prefix = f"tracks/{track_idx}"
 
-    # Build the packed keyframe array
-    # Format: [time, transition, value, time, transition, value, ...]
-    key_values: list[float] = []
+    # Godot 4 value track keys use a dictionary format with separate arrays
+    times: list[float] = []
+    transitions: list[float] = []
+    values: list[float] = []
     for time, value in keyframes:
-        key_values.append(float(time))
-        key_values.append(1.0)  # transition type (1 = linear)
-        if isinstance(value, (int, float)):
-            key_values.append(float(value))
-        else:
-            key_values.append(float(value))
+        times.append(float(time))
+        transitions.append(1.0)  # transition type (1 = linear)
+        values.append(float(value))
+
+    keys_dict: dict[str, Any] = {
+        "times": _packed_float32_array(times),
+        "transitions": _packed_float32_array(transitions),
+        "update": 0,
+        "values": values,
+    }
 
     return {
         f"{prefix}/type": "value",
@@ -60,7 +65,7 @@ def _build_track_properties(
         f"{prefix}/path": NodePath(node_path),
         f"{prefix}/interp": interp_mode,
         f"{prefix}/loop_wrap": True,
-        f"{prefix}/keys": _packed_float32_array(key_values),
+        f"{prefix}/keys": keys_dict,
     }
 
 

--- a/tests/unit/test_animation_commands.py
+++ b/tests/unit/test_animation_commands.py
@@ -130,6 +130,11 @@ class TestAddTrack:
         text = lib.read_text()
         assert "tracks/0/type" in text
         assert "Sprite2D:modulate:a" in text
+        # Godot 4 dict format with separate times/transitions/values arrays
+        assert '"times"' in text
+        assert '"transitions"' in text
+        assert '"values"' in text
+        assert '"update"' in text
         assert "PackedFloat32Array" in text
 
     def test_add_multiple_tracks(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Fix `animation add-track` to generate Godot 4 dictionary format for value track keys instead of the Godot 3 interleaved PackedFloat32Array format
- Godot 4 expects `{"times": PackedFloat32Array(...), "transitions": PackedFloat32Array(...), "update": 0, "values": [...]}` but the command was producing `PackedFloat32Array(time, transition, value, ...)`
- Updated test to verify Godot 4 dictionary format fields (times, transitions, values, update)

## Test plan

- [x] All 16 animation command tests pass
- [x] Full suite: 1422 tests pass with no regressions
- [x] Test verifies Godot 4 dict keys present in output

Fixes #92

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>