### PR TITLE
fix: add default texture to particle presets (#94)

### DIFF
--- a/src/auto_godot/commands/particle.py
+++ b/src/auto_godot/commands/particle.py
@@ -8,13 +8,60 @@ from typing import Any
 import rich_click as click
 
 from auto_godot.errors import ProjectError
+from auto_godot.formats.tres import SubResource
 from auto_godot.formats.tscn import (
     SceneNode,
     parse_tscn,
     serialize_tscn,
 )
-from auto_godot.formats.values import Color, Vector2
+from auto_godot.formats.values import Color, SubResourceRef, Vector2
 from auto_godot.output import emit, emit_error
+
+
+class _RawGodotValue:
+    """Raw Godot value that bypasses serialize_value quoting."""
+
+    def __init__(self, raw: str) -> None:
+        self._raw = raw
+
+    def __str__(self) -> str:
+        return self._raw
+
+    def __repr__(self) -> str:
+        return self._raw
+
+
+def _default_particle_texture_subs(
+    node_name: str,
+) -> tuple[list[SubResource], SubResourceRef]:
+    """Create Gradient + GradientTexture2D SubResources for a particle.
+
+    Returns (sub_resources, texture_ref) where texture_ref is a
+    SubResourceRef to assign to the particle node's texture property.
+    """
+    grad_id = f"{node_name}_grad"
+    tex_id = f"{node_name}_tex"
+
+    gradient = SubResource(
+        type="Gradient",
+        id=grad_id,
+        properties={
+            "colors": _RawGodotValue(
+                "PackedColorArray(1, 1, 1, 1, 1, 1, 1, 0)"
+            ),
+        },
+    )
+    texture = SubResource(
+        type="GradientTexture2D",
+        id=tex_id,
+        properties={
+            "gradient": SubResourceRef(grad_id),
+            "fill": 1,
+            "fill_from": Vector2(0.5, 0.5),
+            "fill_to": Vector2(0.5, 1.0),
+        },
+    )
+    return [gradient, texture], SubResourceRef(tex_id)
 
 
 @click.group(invoke_without_command=True)
@@ -206,6 +253,11 @@ def add(
             props["one_shot"] = one_shot
             if one_shot:
                 props["emitting"] = False
+
+        # Add default particle texture (radial white-to-transparent gradient)
+        tex_subs, tex_ref = _default_particle_texture_subs(node_name)
+        scene.sub_resources.extend(tex_subs)
+        props["texture"] = tex_ref
 
         scene.nodes.append(SceneNode(
             name=node_name,

--- a/tests/unit/test_particle_commands.py
+++ b/tests/unit/test_particle_commands.py
@@ -36,6 +36,20 @@ class TestParticleAdd:
         assert "CPUParticles2D" in text
         assert 'name="Explosion"' in text
 
+    def test_preset_includes_texture(self, tmp_path: Path) -> None:
+        scene = _make_scene(tmp_path)
+        CliRunner().invoke(cli, [
+            "particle", "add",
+            "--scene", str(scene),
+            "--name", "Sparks",
+            "--preset", "sparkle",
+        ])
+        text = scene.read_text()
+        assert 'texture = SubResource("Sparks_tex")' in text
+        assert '[sub_resource type="GradientTexture2D"' in text
+        assert '[sub_resource type="Gradient"' in text
+        assert "PackedColorArray" in text
+
     def test_add_sparkle(self, tmp_path: Path) -> None:
         scene = _make_scene(tmp_path)
         runner = CliRunner()


### PR DESCRIPTION
## Summary

- All particle presets now include an inline GradientTexture2D SubResource (radial white-to-transparent gradient) as the default particle texture
- CPUParticles2D without a texture renders as invisible 1px dots in Godot 4; this fix makes all presets produce visible particles out of the box
- No external PNG files needed; the Gradient + GradientTexture2D are self-contained as SubResources in the scene file
- Custom particles (no preset) also get the default texture

## Test plan

- [x] All 12 particle tests pass (including new texture verification test)
- [x] Full suite: 1422 tests pass with no regressions
- [x] Verified generated .tscn output contains Gradient, GradientTexture2D, and texture = SubResource reference

Fixes #94

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>