### PR TITLE
fix: preset validate exits 1 when warnings found (#101)

### DIFF
--- a/src/auto_godot/commands/preset.py
+++ b/src/auto_godot/commands/preset.py
@@ -426,5 +426,7 @@ def validate(ctx: click.Context, project_path: str) -> None:
             "warnings": warnings,
         }
         emit(data, _display_validate, ctx)
+        if warnings:
+            ctx.exit(1)
     except ProjectError as exc:
         emit_error(exc, ctx)

--- a/tests/unit/test_preset_inspect_validate.py
+++ b/tests/unit/test_preset_inspect_validate.py
@@ -122,7 +122,7 @@ class TestPresetValidate:
         result = CliRunner().invoke(
             cli, ["-j", "preset", "validate", str(tmp_path)]
         )
-        assert result.exit_code == 0  # warnings are informational, not errors
+        assert result.exit_code == 1
         data = json.loads(result.output)
         assert data["valid"] is False
         issues = [w["issue"] for w in data["warnings"]]
@@ -134,7 +134,7 @@ class TestPresetValidate:
         result = CliRunner().invoke(
             cli, ["-j", "preset", "validate", str(tmp_path)]
         )
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         data = json.loads(result.output)
         assert data["valid"] is False
         issues = [w["issue"] for w in data["warnings"]]
@@ -146,7 +146,7 @@ class TestPresetValidate:
         result = CliRunner().invoke(
             cli, ["-j", "preset", "validate", str(tmp_path)]
         )
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         data = json.loads(result.output)
         assert data["valid"] is False
         issues = [w["issue"] for w in data["warnings"]]
@@ -157,7 +157,7 @@ class TestPresetValidate:
         result = CliRunner().invoke(
             cli, ["-j", "preset", "validate", str(tmp_path)]
         )
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         data = json.loads(result.output)
         assert data["valid"] is False
         issues = [w["issue"] for w in data["warnings"]]


### PR DESCRIPTION
## Summary

- `preset validate` now exits 1 when validation warnings are found (matching ruff/eslint/mypy behavior)
- Structured JSON output preserved: `{"valid": false, "warnings": [...]}`
- Exit 0 only when all presets are valid
- Updated 4 tests to expect exit code 1 for warning scenarios

## Test plan

- [x] 12/12 preset tests pass
- [x] 1472/1472 full suite passes

Fixes #101

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>