### PR TITLE
fix: resource dump honors --json error contract for missing files (#102)

### DIFF
--- a/src/auto_godot/commands/resource.py
+++ b/src/auto_godot/commands/resource.py
@@ -445,7 +445,7 @@ _TRES_SECTIONS = ("ext_resources", "sub_resources", "properties")
 
 
 @resource.command("dump")
-@click.argument("file", type=click.Path(exists=True))
+@click.argument("file", type=click.Path())
 @click.option(
     "--section",
     type=str,
@@ -468,6 +468,18 @@ def dump(ctx: click.Context, file: str, section: str | None) -> None:
       auto-godot resource dump spriteframes.tres --section properties
     """
     file_path = Path(file)
+
+    if not file_path.exists():
+        emit_error(
+            ProjectError(
+                message=f"File not found: {file}",
+                code="FILE_NOT_FOUND",
+                fix="Check the file path exists",
+            ),
+            ctx,
+        )
+        return
+
     suffix = file_path.suffix.lower()
 
     if suffix not in (".tres", ".tscn"):

--- a/tests/unit/test_resource_dump.py
+++ b/tests/unit/test_resource_dump.py
@@ -122,3 +122,13 @@ class TestDumpErrors:
     def test_nonexistent_file(self) -> None:
         result = CliRunner().invoke(cli, ["resource", "dump", "/no/such/file.tscn"])
         assert result.exit_code != 0
+
+    def test_nonexistent_file_json_error_contract(self) -> None:
+        result = CliRunner().invoke(
+            cli, ["-j", "resource", "dump", "/no/such/file.tscn"]
+        )
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert "error" in data
+        assert data["code"] == "FILE_NOT_FOUND"
+        assert "fix" in data


### PR DESCRIPTION
## Summary

- Remove `click.Path(exists=True)` from `resource dump` argument to prevent Click from bypassing `emit_error`
- Add manual file existence check that routes through `ProjectError` with proper `{"error", "code", "fix"}` JSON output
- New test verifies the `--json` error contract for missing files

## Test plan

- [x] 15/15 resource dump tests pass (including new JSON error contract test)
- [x] 1473/1473 full suite passes

Fixes #102

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>