### PR TITLE
feat: add sfxr-style retro sound synthesis (#95)

### DIFF
--- a/src/auto_godot/commands/audio.py
+++ b/src/auto_godot/commands/audio.py
@@ -310,6 +310,136 @@ def _parse_bus_layout(text: str) -> list[dict[str, Any]]:
 
 
 # ---------------------------------------------------------------------------
+# audio generate (sfxr-style retro sound synthesis)
+# ---------------------------------------------------------------------------
+
+_SFXR_WAVE_TYPES = ["square", "sawtooth", "sine", "noise", "triangle"]
+
+
+@audio.command("generate")
+@click.option(
+    "--preset", "preset_name",
+    type=click.Choice([
+        "coin-pickup", "powerup", "explosion", "laser",
+        "jump", "hit", "blip", "success",
+    ]),
+    default=None,
+    help="Named preset for common retro sounds.",
+)
+@click.option(
+    "--seed", type=int, default=None,
+    help="Random seed for reproducible variation.",
+)
+@click.option(
+    "--wave", "wave_type",
+    type=click.Choice(_SFXR_WAVE_TYPES),
+    default=None,
+    help="Waveform type (overrides preset).",
+)
+@click.option("--frequency", type=float, default=None, help="Base frequency in Hz.")
+@click.option("--attack", type=float, default=None, help="Attack time in seconds.")
+@click.option("--sustain", type=float, default=None, help="Sustain time in seconds.")
+@click.option("--decay", type=float, default=None, help="Decay time in seconds.")
+@click.option("--freq-slide", type=float, default=None, help="Frequency slide in Hz/s.")
+@click.option(
+    "--sample-rate", type=int, default=22050,
+    help="Sample rate (default: 22050).",
+)
+@click.argument("output_path", type=click.Path())
+@click.pass_context
+def generate(
+    ctx: click.Context,
+    preset_name: str | None,
+    seed: int | None,
+    wave_type: str | None,
+    frequency: float | None,
+    attack: float | None,
+    sustain: float | None,
+    decay: float | None,
+    freq_slide: float | None,
+    sample_rate: int,
+    output_path: str,
+) -> None:
+    """Generate retro sfxr-style sound effects.
+
+    Uses sfxr-inspired synthesis with presets for common game sounds.
+    Each preset can be varied with --seed for unique variations.
+
+    Examples:
+
+      auto-godot audio generate --preset coin-pickup assets/audio/coin.wav
+
+      auto-godot audio generate --preset explosion --seed 42 assets/audio/boom.wav
+
+      auto-godot audio generate --wave square --frequency 880 --decay 0.3 assets/audio/custom.wav
+    """
+    from auto_godot.sfxr import SfxrParams, make_preset, synthesize, write_wav
+
+    try:
+        if preset_name:
+            params = make_preset(preset_name, seed)
+        elif wave_type or frequency is not None:
+            params = SfxrParams(
+                wave_type=wave_type or "sine",
+                base_freq=frequency or 440.0,
+                attack=attack or 0.0,
+                sustain=sustain if sustain is not None else 0.1,
+                decay=decay if decay is not None else 0.3,
+                freq_slide=freq_slide or 0.0,
+            )
+        else:
+            raise ProjectError(
+                message="Specify --preset or --wave/--frequency for custom synthesis",
+                code="MISSING_PARAMS",
+                fix="Use --preset coin-pickup or --wave square --frequency 440",
+            )
+
+        # Apply per-parameter overrides on top of preset
+        if preset_name:
+            if wave_type is not None:
+                params.wave_type = wave_type
+            if frequency is not None:
+                params.base_freq = frequency
+            if attack is not None:
+                params.attack = attack
+            if sustain is not None:
+                params.sustain = sustain
+            if decay is not None:
+                params.decay = decay
+            if freq_slide is not None:
+                params.freq_slide = freq_slide
+
+        params.sample_rate = sample_rate
+        samples = synthesize(params, seed)
+        out = Path(output_path)
+        file_size = write_wav(samples, out, sample_rate)
+
+        data = {
+            "created": True,
+            "path": str(out),
+            "preset": preset_name,
+            "wave_type": params.wave_type,
+            "frequency": params.base_freq,
+            "duration_ms": int(params.duration * 1000),
+            "sample_rate": sample_rate,
+            "seed": seed,
+            "file_size": file_size,
+        }
+
+        def _human(data: dict[str, Any], verbose: bool = False) -> None:
+            label = data["preset"] or data["wave_type"]
+            click.echo(
+                f"Generated {label} sound: {data['path']} "
+                f"({data['duration_ms']}ms, {data['frequency']:.0f}Hz, "
+                f"{data['file_size']} bytes)"
+            )
+
+        emit(data, _human, ctx)
+    except ProjectError as exc:
+        emit_error(exc, ctx)
+
+
+# ---------------------------------------------------------------------------
 # audio generate-placeholder
 # ---------------------------------------------------------------------------
 

--- a/src/auto_godot/commands/audio.py
+++ b/src/auto_godot/commands/audio.py
@@ -437,6 +437,15 @@ def generate(
         emit(data, _human, ctx)
     except ProjectError as exc:
         emit_error(exc, ctx)
+    except Exception as exc:
+        emit_error(
+            ProjectError(
+                message=f"Failed to generate sound: {exc}",
+                code="GENERATE_ERROR",
+                fix="Check parameters and output path",
+            ),
+            ctx,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/auto_godot/sfxr.py
+++ b/src/auto_godot/sfxr.py
@@ -1,0 +1,170 @@
+"""Pure Python sfxr-style retro sound synthesizer."""
+
+from __future__ import annotations
+
+import math
+import random
+import struct
+import wave
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class SfxrParams:
+    """Parameters controlling sfxr sound generation."""
+
+    wave_type: str = "square"
+    sample_rate: int = 22050
+    base_freq: float = 440.0
+    freq_limit: float = 0.0
+    freq_slide: float = 0.0
+    duty_cycle: float = 0.5
+    attack: float = 0.0
+    sustain: float = 0.1
+    decay: float = 0.3
+    volume: float = 0.8
+    arp_speed: float = 0.0
+    arp_mult: float = 1.0
+
+    @property
+    def duration(self) -> float:
+        return self.attack + self.sustain + self.decay
+
+
+def synthesize(params: SfxrParams, seed: int | None = None) -> list[int]:
+    """Generate 16-bit signed audio samples from sfxr parameters."""
+    rng = random.Random(seed)
+    sr = params.sample_rate
+    num_samples = int(sr * params.duration)
+    if num_samples == 0:
+        return []
+
+    samples: list[int] = []
+    phase = 0.0
+    freq = params.base_freq
+    arp_triggered = False
+    noise_buffer = [rng.uniform(-1.0, 1.0) for _ in range(32)]
+
+    for i in range(num_samples):
+        t = i / sr
+        amp = _envelope(t, params.attack, params.sustain, params.decay)
+
+        freq += params.freq_slide / sr
+        if params.freq_limit > 0.0 and freq < params.freq_limit:
+            break
+
+        if params.arp_speed > 0.0 and t >= params.arp_speed and not arp_triggered:
+            freq *= params.arp_mult
+            arp_triggered = True
+
+        effective_freq = max(1.0, freq)
+        phase += effective_freq / sr
+        phase %= 1.0
+
+        val = _waveform(params.wave_type, phase, params.duty_cycle, noise_buffer)
+        sample = int(val * amp * params.volume * 32767)
+        samples.append(max(-32768, min(32767, sample)))
+
+    return samples
+
+
+def write_wav(samples: list[int], path: Path, sample_rate: int = 22050) -> int:
+    """Write samples to a WAV file. Returns file size in bytes."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "w") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(struct.pack(f"<{len(samples)}h", *samples))
+    return path.stat().st_size
+
+
+def _envelope(t: float, attack: float, sustain: float, decay: float) -> float:
+    if attack > 0.0 and t < attack:
+        return t / attack
+    t -= attack
+    if t < sustain:
+        return 1.0
+    t -= sustain
+    if decay > 0.0 and t < decay:
+        return 1.0 - (t / decay)
+    return 0.0
+
+
+def _waveform(
+    wave_type: str, phase: float, duty: float, noise_buf: list[float]
+) -> float:
+    if wave_type == "square":
+        return 1.0 if phase < duty else -1.0
+    if wave_type == "sawtooth":
+        return 2.0 * phase - 1.0
+    if wave_type == "sine":
+        return math.sin(2.0 * math.pi * phase)
+    if wave_type == "triangle":
+        return 4.0 * abs(phase - 0.5) - 1.0
+    if wave_type == "noise":
+        return noise_buf[int(phase * len(noise_buf)) % len(noise_buf)]
+    return 0.0
+
+
+# Preset definitions: {param: (base, spread)} for randomized values,
+# plain values for wave_type and volume.
+_PRESET_DEFS: dict[str, dict[str, tuple[float, float] | str | float]] = {
+    "coin-pickup": {
+        "wave_type": "square", "volume": 0.7, "duty_cycle": (0.5, 0.0),
+        "base_freq": (600.0, 50.0), "sustain": (0.04, 0.01),
+        "decay": (0.15, 0.03), "arp_speed": (0.04, 0.01), "arp_mult": (1.5, 0.1),
+    },
+    "powerup": {
+        "wave_type": "square", "volume": 0.7, "duty_cycle": (0.5, 0.0),
+        "base_freq": (300.0, 30.0), "freq_slide": (800.0, 100.0),
+        "sustain": (0.15, 0.03), "decay": (0.3, 0.05),
+    },
+    "explosion": {
+        "wave_type": "noise", "volume": 0.8,
+        "base_freq": (150.0, 30.0), "freq_slide": (-50.0, 20.0),
+        "sustain": (0.05, 0.02), "decay": (0.5, 0.1),
+    },
+    "laser": {
+        "wave_type": "square", "volume": 0.7, "duty_cycle": (0.3, 0.0),
+        "base_freq": (900.0, 100.0), "freq_slide": (-600.0, 80.0),
+        "sustain": (0.05, 0.01), "decay": (0.15, 0.03),
+    },
+    "jump": {
+        "wave_type": "sine", "volume": 0.7,
+        "base_freq": (300.0, 30.0), "freq_slide": (500.0, 60.0),
+        "sustain": (0.05, 0.01), "decay": (0.2, 0.03),
+    },
+    "hit": {
+        "wave_type": "noise", "volume": 0.8,
+        "base_freq": (400.0, 50.0), "freq_slide": (-100.0, 30.0),
+        "sustain": (0.02, 0.005), "decay": (0.15, 0.03),
+    },
+    "blip": {
+        "wave_type": "sine", "volume": 0.6,
+        "base_freq": (800.0, 60.0), "sustain": (0.03, 0.005),
+        "decay": (0.08, 0.02),
+    },
+    "success": {
+        "wave_type": "square", "volume": 0.7, "duty_cycle": (0.5, 0.0),
+        "base_freq": (500.0, 30.0), "arp_speed": (0.08, 0.01),
+        "arp_mult": (1.25, 0.05), "sustain": (0.1, 0.02), "decay": (0.35, 0.05),
+    },
+}
+
+PRESET_NAMES: list[str] = list(_PRESET_DEFS.keys())
+
+
+def make_preset(name: str, seed: int | None = None) -> SfxrParams:
+    """Build SfxrParams for a named preset with optional seed variation."""
+    defn = _PRESET_DEFS[name]
+    rng = random.Random(seed)
+    kwargs: dict[str, object] = {}
+    for key, val in defn.items():
+        if isinstance(val, tuple):
+            base, spread = val
+            kwargs[key] = base + rng.uniform(-spread, spread)
+        else:
+            kwargs[key] = val
+    return SfxrParams(**kwargs)  # type: ignore[arg-type]

--- a/tests/unit/test_sfxr.py
+++ b/tests/unit/test_sfxr.py
@@ -1,0 +1,133 @@
+"""Tests for sfxr synthesizer and audio generate command."""
+
+from __future__ import annotations
+
+import json
+import wave
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from auto_godot.cli import cli
+from auto_godot.sfxr import PRESET_NAMES, SfxrParams, make_preset, synthesize, write_wav
+
+
+class TestSynthesizeCore:
+
+    def test_default_params_produce_samples(self) -> None:
+        samples = synthesize(SfxrParams())
+        assert len(samples) > 0
+        assert all(-32768 <= s <= 32767 for s in samples)
+
+    def test_seed_deterministic(self) -> None:
+        params = SfxrParams(wave_type="noise", base_freq=400.0, decay=0.2)
+        assert synthesize(params, seed=42) == synthesize(params, seed=42)
+
+    def test_different_seeds_differ(self) -> None:
+        params = SfxrParams(wave_type="noise", base_freq=400.0, decay=0.2)
+        assert synthesize(params, seed=1) != synthesize(params, seed=2)
+
+    def test_zero_duration_returns_empty(self) -> None:
+        assert synthesize(SfxrParams(attack=0.0, sustain=0.0, decay=0.0)) == []
+
+    def test_all_wave_types(self) -> None:
+        for wt in ("square", "sawtooth", "sine", "noise", "triangle"):
+            samples = synthesize(SfxrParams(wave_type=wt, sustain=0.05, decay=0.05), seed=1)
+            assert len(samples) > 0, f"wave_type={wt} produced no samples"
+
+    def test_frequency_slide_and_arpeggio(self) -> None:
+        params = SfxrParams(base_freq=440.0, freq_slide=500.0, arp_speed=0.05, arp_mult=1.5, decay=0.2)
+        assert len(synthesize(params, seed=0)) > 0
+
+    def test_freq_limit_stops_early(self) -> None:
+        params = SfxrParams(base_freq=200.0, freq_slide=-2000.0, freq_limit=100.0, sustain=0.5, decay=0.5)
+        assert len(synthesize(params)) < int(params.sample_rate * params.duration)
+
+
+class TestWriteWav:
+
+    def test_writes_valid_wav(self, tmp_path: Path) -> None:
+        samples = synthesize(SfxrParams(sustain=0.05, decay=0.05))
+        out = tmp_path / "test.wav"
+        assert write_wav(samples, out) > 0
+        with wave.open(str(out), "r") as wf:
+            assert wf.getnchannels() == 1
+            assert wf.getsampwidth() == 2
+            assert wf.getnframes() == len(samples)
+
+    def test_creates_parent_dirs(self, tmp_path: Path) -> None:
+        out = tmp_path / "nested" / "dir" / "sound.wav"
+        write_wav(synthesize(SfxrParams(sustain=0.05, decay=0.05)), out)
+        assert out.exists()
+
+
+class TestPresets:
+
+    def test_all_presets_exist(self) -> None:
+        expected = {"coin-pickup", "powerup", "explosion", "laser", "jump", "hit", "blip", "success"}
+        assert set(PRESET_NAMES) == expected
+
+    def test_each_preset_generates_samples(self) -> None:
+        for name in PRESET_NAMES:
+            samples = synthesize(make_preset(name, seed=0), seed=0)
+            assert len(samples) > 0, f"Preset '{name}' produced no samples"
+
+    def test_presets_deterministic_with_seed(self) -> None:
+        for name in PRESET_NAMES:
+            s1 = synthesize(make_preset(name, seed=42), seed=42)
+            s2 = synthesize(make_preset(name, seed=42), seed=42)
+            assert s1 == s2, f"Preset '{name}' not deterministic"
+
+
+class TestAudioGenerateCommand:
+
+    def test_generate_with_preset(self, tmp_path: Path) -> None:
+        out = tmp_path / "coin.wav"
+        result = CliRunner().invoke(cli, ["audio", "generate", "--preset", "coin-pickup", str(out)])
+        assert result.exit_code == 0, result.output
+        assert out.exists()
+
+    def test_generate_with_seed_deterministic(self, tmp_path: Path) -> None:
+        out1, out2 = tmp_path / "a.wav", tmp_path / "b.wav"
+        runner = CliRunner()
+        runner.invoke(cli, ["audio", "generate", "--preset", "laser", "--seed", "42", str(out1)])
+        runner.invoke(cli, ["audio", "generate", "--preset", "laser", "--seed", "42", str(out2)])
+        assert out1.read_bytes() == out2.read_bytes()
+
+    def test_generate_custom_params(self, tmp_path: Path) -> None:
+        out = tmp_path / "custom.wav"
+        result = CliRunner().invoke(cli, [
+            "audio", "generate", "--wave", "square", "--frequency", "880", "--decay", "0.2", str(out),
+        ])
+        assert result.exit_code == 0, result.output
+        assert out.exists()
+
+    def test_generate_preset_with_overrides(self, tmp_path: Path) -> None:
+        out = tmp_path / "modified.wav"
+        result = CliRunner().invoke(cli, [
+            "audio", "generate", "--preset", "explosion", "--decay", "1.0", str(out),
+        ])
+        assert result.exit_code == 0, result.output
+
+    def test_generate_no_params_errors(self) -> None:
+        assert CliRunner().invoke(cli, ["audio", "generate", "output.wav"]).exit_code != 0
+
+    def test_generate_json_output(self, tmp_path: Path) -> None:
+        out = tmp_path / "coin.wav"
+        result = CliRunner().invoke(cli, [
+            "-j", "audio", "generate", "--preset", "coin-pickup", "--seed", "7", str(out),
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["created"] is True
+        assert data["preset"] == "coin-pickup"
+        assert data["seed"] == 7
+        assert data["file_size"] > 0
+
+    def test_generate_with_freq_slide(self, tmp_path: Path) -> None:
+        out = tmp_path / "slide.wav"
+        result = CliRunner().invoke(cli, [
+            "audio", "generate", "--wave", "square", "--frequency", "880", "--freq-slide", "-500", str(out),
+        ])
+        assert result.exit_code == 0, result.output
+        assert out.exists()


### PR DESCRIPTION
## Summary
- Adds `audio generate` command with 8 sfxr-style presets: coin-pickup, powerup, explosion, laser, jump, hit, blip, success
- Pure Python implementation (no new dependencies) using waveform synthesis with envelope shaping, frequency slides, and arpeggiation
- Supports `--seed` for reproducible variation and custom parameter overrides (`--wave`, `--frequency`, `--attack`, `--sustain`, `--decay`, `--freq-slide`)
- 19 unit tests covering synthesizer core, WAV output, all presets, and CLI integration

## Test plan
- [x] All 19 new tests pass (`pytest tests/unit/test_sfxr.py -v`)
- [x] No regressions in existing tests (pre-existing async test failures unrelated)
- [x] Each preset generates valid WAV files
- [x] `--seed` produces deterministic output
- [x] JSON output follows error contract
- [x] Custom parameters work both standalone and as preset overrides

Fixes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)