### PR TITLE
feat: add --pixel-art flag to project set-display (#113)

### DIFF
--- a/src/auto_godot/commands/project.py
+++ b/src/auto_godot/commands/project.py
@@ -1563,6 +1563,10 @@ def remove_input(
     type=click.Choice(["nearest", "linear"]),
     help="Default texture filter (nearest for pixel art)",
 )
+@click.option(
+    "--pixel-art", "pixel_art", is_flag=True, default=False,
+    help="Apply all pixel-perfect settings at once (viewport stretch, nearest filter, snap, integer scaling)",
+)
 @click.argument("project_path", default=".", type=click.Path())
 @click.pass_context
 def set_display(
@@ -1574,6 +1578,7 @@ def set_display(
     stretch_mode: str | None,
     stretch_aspect: str | None,
     texture_filter: str | None,
+    pixel_art: bool,
     project_path: str,
 ) -> None:
     """Configure display/window settings in project.godot.
@@ -1582,12 +1587,21 @@ def set_display(
 
       auto-godot project set-display --width 320 --height 180 --window-width 1280 --window-height 720
 
-      auto-godot project set-display --stretch-mode viewport --stretch-aspect keep --texture-filter nearest
+      auto-godot project set-display --width 320 --height 240 --window-width 960 --window-height 720 --pixel-art
     """
     try:
         project_godot = _find_project_godot(project_path)
         changed: list[str] = []
         settings: list[tuple[str, str, str]] = []
+
+        # --pixel-art sets defaults that explicit options can override
+        if pixel_art:
+            if stretch_mode is None:
+                stretch_mode = "viewport"
+            if stretch_aspect is None:
+                stretch_aspect = "keep"
+            if texture_filter is None:
+                texture_filter = "nearest"
 
         if width is not None:
             settings.append(("display", "window/size/viewport_width", str(width)))
@@ -1612,11 +1626,20 @@ def set_display(
             settings.append(("rendering", "textures/canvas_textures/default_texture_filter", val))
             changed.append(f"texture_filter={texture_filter}")
 
+        # --pixel-art also sets snap and integer scaling
+        if pixel_art:
+            settings.append(("rendering", "2d/snap/snap_2d_transforms_to_pixel", "true"))
+            changed.append("snap_2d_transforms_to_pixel=true")
+            settings.append(("rendering", "2d/snap/snap_2d_vertices_to_pixel", "false"))
+            changed.append("snap_2d_vertices_to_pixel=false")
+            settings.append(("display", "window/stretch/scale_mode", '"integer"'))
+            changed.append('scale_mode=integer')
+
         if not settings:
             raise ProjectError(
                 message="No display settings specified",
                 code="NO_SETTINGS",
-                fix="Provide at least one display option (--width, --height, etc.)",
+                fix="Provide at least one display option (--width, --height, --pixel-art, etc.)",
             )
 
         for section, key, value in settings:

--- a/tests/unit/test_display_commands.py
+++ b/tests/unit/test_display_commands.py
@@ -187,7 +187,7 @@ class TestSetDisplayUpdateExisting:
 class TestPixelArtSetup:
     """Integration test: configure for pixel art game."""
 
-    def test_pixel_art_config(self, tmp_path: Path) -> None:
+    def test_pixel_art_config_manual(self, tmp_path: Path) -> None:
         _make_project(tmp_path)
         runner = CliRunner()
         result = runner.invoke(cli, [
@@ -204,3 +204,66 @@ class TestPixelArtSetup:
         assert "viewport_width=480" in text
         assert "viewport_height=270" in text
         assert "default_texture_filter=0" in text
+
+
+class TestPixelArtFlag:
+    """Verify --pixel-art flag sets all pixel-perfect settings."""
+
+    def test_pixel_art_flag_sets_all(self, tmp_path: Path) -> None:
+        _make_project(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "project", "set-display",
+            "--width", "320", "--height", "240",
+            "--window-width", "960", "--window-height", "720",
+            "--pixel-art",
+            str(tmp_path),
+        ])
+        assert result.exit_code == 0, result.output
+        text = (tmp_path / "project.godot").read_text()
+        assert "viewport_width=320" in text
+        assert "viewport_height=240" in text
+        assert 'window/stretch/mode="viewport"' in text
+        assert 'window/stretch/aspect="keep"' in text
+        assert "default_texture_filter=0" in text
+        assert "snap_2d_transforms_to_pixel=true" in text
+        assert "snap_2d_vertices_to_pixel=false" in text
+        assert 'window/stretch/scale_mode="integer"' in text
+
+    def test_pixel_art_flag_alone(self, tmp_path: Path) -> None:
+        _make_project(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "project", "set-display", "--pixel-art", str(tmp_path),
+        ])
+        assert result.exit_code == 0, result.output
+        text = (tmp_path / "project.godot").read_text()
+        assert 'window/stretch/mode="viewport"' in text
+        assert "snap_2d_transforms_to_pixel=true" in text
+
+    def test_pixel_art_with_stretch_override(self, tmp_path: Path) -> None:
+        _make_project(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "project", "set-display",
+            "--pixel-art", "--stretch-mode", "canvas_items",
+            str(tmp_path),
+        ])
+        assert result.exit_code == 0
+        text = (tmp_path / "project.godot").read_text()
+        # Explicit override wins over --pixel-art default
+        assert 'window/stretch/mode="canvas_items"' in text
+        # But other pixel-art settings still apply
+        assert "snap_2d_transforms_to_pixel=true" in text
+
+    def test_pixel_art_json_output(self, tmp_path: Path) -> None:
+        _make_project(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "-j", "project", "set-display", "--pixel-art", str(tmp_path),
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["updated"] is True
+        # stretch_mode, stretch_aspect, texture_filter, snap_transforms, snap_vertices, scale_mode
+        assert data["count"] == 6


### PR DESCRIPTION
## Summary
- Adds `--pixel-art` flag to `project set-display` that sets all 6 pixel-perfect rendering settings in one command
- Sets: viewport stretch mode, keep aspect, nearest texture filter, snap_2d_transforms_to_pixel, no vertex snap, integer scaling
- Explicit options (e.g. `--stretch-mode canvas_items`) override the preset defaults
- 4 new tests covering full flag behavior, standalone usage, overrides, and JSON output

## Test plan
- [x] All 16 display tests pass (12 existing + 4 new)
- [x] `--pixel-art` flag alone sets all 6 settings
- [x] `--pixel-art` combined with `--width/--height` works correctly
- [x] Explicit stretch-mode override takes precedence over `--pixel-art` default
- [x] JSON output shows correct count of changes

Fixes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)