### PR TITLE
feat: add scene tree command for visual hierarchy view (#109)

### DIFF
--- a/src/auto_godot/commands/scene.py
+++ b/src/auto_godot/commands/scene.py
@@ -1179,6 +1179,98 @@ def list_nodes(ctx: click.Context, scene_path: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# scene tree
+# ---------------------------------------------------------------------------
+
+
+@scene.command("tree")
+@click.argument("scene_path", type=click.Path(exists=True))
+@click.option("--no-types", is_flag=True, help="Hide node type annotations")
+@click.pass_context
+def tree_cmd(ctx: click.Context, scene_path: str, no_types: bool) -> None:
+    """Display scene hierarchy as an indented tree.
+
+    Examples:
+
+      auto-godot scene tree scenes/main.tscn
+
+      auto-godot scene tree --no-types scenes/player.tscn
+    """
+    try:
+        text = Path(scene_path).read_text(encoding="utf-8")
+        scene_data = parse_tscn(text)
+        nodes = scene_data.nodes
+        if not nodes:
+            raise ProjectError(
+                message="Scene has no nodes",
+                code="EMPTY_SCENE",
+                fix="Ensure the file is a valid .tscn scene with at least one node",
+            )
+
+        root = nodes[0]
+        # Map full path -> list of child nodes
+        children: dict[str, list[SceneNode]] = {}
+        for node in nodes[1:]:
+            parent_key = node.parent or "."
+            children.setdefault(parent_key, []).append(node)
+
+        def _node_path(node: SceneNode) -> str:
+            if node.parent is None or node.parent == "":
+                return "."
+            if node.parent == ".":
+                return node.name
+            return f"{node.parent}/{node.name}"
+
+        def _build_json(node: SceneNode) -> dict[str, Any]:
+            path = _node_path(node)
+            entry: dict[str, Any] = {"name": node.name}
+            if node.type:
+                entry["type"] = node.type
+            if node.instance:
+                entry["instance"] = node.instance
+            child_nodes = children.get(path, [])
+            if child_nodes:
+                entry["children"] = [_build_json(c) for c in child_nodes]
+            return entry
+
+        data = {
+            "tree": _build_json(root),
+            "count": len(nodes),
+            "scene": scene_path,
+        }
+
+        def _human(data: dict[str, Any], verbose: bool = False) -> None:
+            def _label(node: SceneNode) -> str:
+                if no_types:
+                    return node.name
+                type_str = node.type or "instance"
+                return f"{node.name} [{type_str}]"
+
+            rich_tree = Tree(_label(root))
+
+            def _add_children(parent_tree: Tree, parent_path: str) -> None:
+                for child in children.get(parent_path, []):
+                    child_tree = parent_tree.add(_label(child))
+                    _add_children(child_tree, _node_path(child))
+
+            _add_children(rich_tree, ".")
+            Console().print(rich_tree)
+
+        emit(data, _human, ctx)
+    except ProjectError as exc:
+        emit_error(exc, ctx)
+    except Exception as exc:
+        emit_error(
+            ProjectError(
+                message=f"Failed to parse scene: {exc}",
+                code="PARSE_ERROR",
+                fix="Ensure the file is a valid .tscn scene file",
+            ),
+            ctx,
+        )
+
+
+# ---------------------------------------------------------------------------
 # scene count-nodes
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_scene_tree.py
+++ b/tests/unit/test_scene_tree.py
@@ -1,0 +1,92 @@
+"""Tests for scene tree command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from auto_godot.cli import cli
+
+
+def _make_scene(tmp_path: Path) -> Path:
+    scene_file = tmp_path / "main.tscn"
+    scene_file.write_text(
+        '[gd_scene format=3]\n\n'
+        '[node name="Main" type="Node2D"]\n\n'
+        '[node name="Player" type="CharacterBody2D" parent="."]\n\n'
+        '[node name="Sprite" type="Sprite2D" parent="Player"]\n\n'
+        '[node name="CollisionShape" type="CollisionShape2D" parent="Player"]\n\n'
+        '[node name="Timer" type="Timer" parent="."]\n\n'
+        '[node name="UI" type="CanvasLayer" parent="."]\n\n'
+        '[node name="HUD" type="Control" parent="UI"]\n\n'
+        '[node name="HealthBar" type="ProgressBar" parent="UI/HUD"]\n',
+        encoding="utf-8",
+    )
+    return scene_file
+
+
+class TestSceneTree:
+
+    def test_tree_output_contains_all_nodes(self, tmp_path: Path) -> None:
+        scene = _make_scene(tmp_path)
+        result = CliRunner().invoke(cli, ["scene", "tree", str(scene)])
+        assert result.exit_code == 0, result.output
+        for name in ("Main", "Player", "Sprite", "CollisionShape", "Timer", "UI", "HUD", "HealthBar"):
+            assert name in result.output
+
+    def test_tree_shows_types(self, tmp_path: Path) -> None:
+        scene = _make_scene(tmp_path)
+        result = CliRunner().invoke(cli, ["scene", "tree", str(scene)])
+        assert "Node2D" in result.output
+        assert "CharacterBody2D" in result.output
+        assert "ProgressBar" in result.output
+
+    def test_tree_no_types(self, tmp_path: Path) -> None:
+        scene = _make_scene(tmp_path)
+        result = CliRunner().invoke(cli, ["scene", "tree", "--no-types", str(scene)])
+        assert result.exit_code == 0
+        assert "Main" in result.output
+        # Types should not appear
+        assert "Node2D" not in result.output
+        assert "CharacterBody2D" not in result.output
+
+    def test_tree_json_nested(self, tmp_path: Path) -> None:
+        scene = _make_scene(tmp_path)
+        result = CliRunner().invoke(cli, ["-j", "scene", "tree", str(scene)])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["count"] == 8
+        tree = data["tree"]
+        assert tree["name"] == "Main"
+        assert tree["type"] == "Node2D"
+        # Player is a child of root
+        player = next(c for c in tree["children"] if c["name"] == "Player")
+        assert player["type"] == "CharacterBody2D"
+        # Sprite is a child of Player
+        sprite = next(c for c in player["children"] if c["name"] == "Sprite")
+        assert sprite["type"] == "Sprite2D"
+
+    def test_tree_json_deep_nesting(self, tmp_path: Path) -> None:
+        scene = _make_scene(tmp_path)
+        result = CliRunner().invoke(cli, ["-j", "scene", "tree", str(scene)])
+        data = json.loads(result.output)
+        tree = data["tree"]
+        ui = next(c for c in tree["children"] if c["name"] == "UI")
+        hud = next(c for c in ui["children"] if c["name"] == "HUD")
+        health = next(c for c in hud["children"] if c["name"] == "HealthBar")
+        assert health["type"] == "ProgressBar"
+
+    def test_single_root(self, tmp_path: Path) -> None:
+        scene = tmp_path / "root.tscn"
+        scene.write_text(
+            '[gd_scene format=3]\n\n[node name="Root" type="Node"]\n',
+            encoding="utf-8",
+        )
+        result = CliRunner().invoke(cli, ["-j", "scene", "tree", str(scene)])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["count"] == 1
+        assert data["tree"]["name"] == "Root"
+        assert "children" not in data["tree"]


### PR DESCRIPTION
## Summary
- Adds `scene tree` command that displays scene node hierarchy as an indented tree
- Uses Rich tree rendering for human-readable output matching Godot editor's scene panel
- `--json` outputs nested children arrays for programmatic use
- `--no-types` flag hides type annotations for cleaner output
- 6 unit tests covering all output modes and nesting levels

## Test plan
- [x] All 6 tests pass (`pytest tests/unit/test_scene_tree.py -v`)
- [x] Tree renders correctly for flat, nested, and deeply nested scenes
- [x] `--no-types` hides type annotations
- [x] JSON output produces correct nested structure
- [x] Single-root scene renders without children key

Fixes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)