### PR TITLE
feat: add scene diff command for structural comparison (#108)

### DIFF
--- a/src/auto_godot/commands/scene.py
+++ b/src/auto_godot/commands/scene.py
@@ -2144,3 +2144,115 @@ def validate_scene(ctx: click.Context, scene_path: str) -> None:
             ),
             ctx,
         )
+
+
+# ---------------------------------------------------------------------------
+# scene diff
+# ---------------------------------------------------------------------------
+
+
+def _node_full_path(node: SceneNode) -> str:
+    """Compute comparison key for a node."""
+    if node.parent is None or node.parent == "":
+        return node.name
+    if node.parent == ".":
+        return node.name
+    return f"{node.parent}/{node.name}"
+
+
+def _diff_properties(
+    old_props: dict[str, Any], new_props: dict[str, Any]
+) -> dict[str, Any]:
+    """Compare two property dicts. Returns changes as {key: {old, new}}."""
+    changes: dict[str, Any] = {}
+    for key in sorted(set(old_props) | set(new_props)):
+        old_val = old_props.get(key)
+        new_val = new_props.get(key)
+        if str(old_val) != str(new_val):
+            changes[key] = {
+                "old": str(old_val) if old_val is not None else None,
+                "new": str(new_val) if new_val is not None else None,
+            }
+    return changes
+
+
+@scene.command("diff")
+@click.argument("scene_a", type=click.Path(exists=True))
+@click.argument("scene_b", type=click.Path(exists=True))
+@click.pass_context
+def diff_scenes(ctx: click.Context, scene_a: str, scene_b: str) -> None:
+    """Structurally compare two .tscn scene files.
+
+    Reports added, removed, and modified nodes with property changes.
+    Ignores non-semantic differences like key ordering.
+
+    Examples:
+
+      auto-godot scene diff scenes/old.tscn scenes/new.tscn
+    """
+    try:
+        a_data = parse_tscn(Path(scene_a).read_text(encoding="utf-8"))
+        b_data = parse_tscn(Path(scene_b).read_text(encoding="utf-8"))
+
+        a_map = {_node_full_path(n): n for n in a_data.nodes}
+        b_map = {_node_full_path(n): n for n in b_data.nodes}
+        a_paths, b_paths = set(a_map), set(b_map)
+
+        added = sorted(b_paths - a_paths)
+        removed = sorted(a_paths - b_paths)
+        modified: list[dict[str, Any]] = []
+        for path in sorted(a_paths & b_paths):
+            prop_diff = _diff_properties(a_map[path].properties, b_map[path].properties)
+            type_changed = a_map[path].type != b_map[path].type
+            if prop_diff or type_changed:
+                entry: dict[str, Any] = {"path": path}
+                if type_changed:
+                    entry["type"] = {"old": a_map[path].type, "new": b_map[path].type}
+                if prop_diff:
+                    entry["properties"] = prop_diff
+                modified.append(entry)
+
+        a_conns = {(c.signal, c.from_node, c.to_node, c.method) for c in a_data.connections}
+        b_conns = {(c.signal, c.from_node, c.to_node, c.method) for c in b_data.connections}
+        added_conns = [{"signal": s, "from": f, "to": t, "method": m} for s, f, t, m in sorted(b_conns - a_conns)]
+        removed_conns = [{"signal": s, "from": f, "to": t, "method": m} for s, f, t, m in sorted(a_conns - b_conns)]
+
+        has_changes = bool(added or removed or modified or added_conns or removed_conns)
+        data: dict[str, Any] = {
+            "has_changes": has_changes,
+            "added_nodes": [{"path": p, "type": b_map[p].type} for p in added],
+            "removed_nodes": [{"path": p, "type": a_map[p].type} for p in removed],
+            "modified_nodes": modified,
+            "added_connections": added_conns,
+            "removed_connections": removed_conns,
+        }
+
+        def _human(data: dict[str, Any], verbose: bool = False) -> None:
+            if not data["has_changes"]:
+                click.echo("Scenes are structurally identical.")
+                return
+            for n in data["added_nodes"]:
+                click.echo(f"  + {n['path']} [{n['type']}]")
+            for n in data["removed_nodes"]:
+                click.echo(f"  - {n['path']} [{n['type']}]")
+            for n in data["modified_nodes"]:
+                click.echo(f"  ~ {n['path']}")
+                if "type" in n:
+                    click.echo(f"      type: {n['type']['old']} -> {n['type']['new']}")
+                for prop, ch in n.get("properties", {}).items():
+                    click.echo(f"      {prop}: {ch['old'] or '(unset)'} -> {ch['new'] or '(unset)'}")
+            for c in data["added_connections"]:
+                click.echo(f"  + connection: {c['signal']} {c['from']} -> {c['to']}.{c['method']}")
+            for c in data["removed_connections"]:
+                click.echo(f"  - connection: {c['signal']} {c['from']} -> {c['to']}.{c['method']}")
+
+        emit(data, _human, ctx)
+    except Exception as exc:
+        emit_error(
+            ProjectError(
+                message=f"Failed to diff scenes: {exc}",
+                code="DIFF_ERROR",
+                fix="Ensure both files are valid .tscn scene files",
+            ),
+            ctx,
+        )

--- a/tests/unit/test_scene_diff.py
+++ b/tests/unit/test_scene_diff.py
@@ -1,0 +1,106 @@
+"""Tests for scene diff command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from auto_godot.cli import cli
+
+
+def _write_scene(path: Path, content: str) -> Path:
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+SCENE_BASE = (
+    '[gd_scene format=3]\n\n'
+    '[node name="Main" type="Node2D"]\n\n'
+    '[node name="Player" type="CharacterBody2D" parent="."]\n\n'
+    '[node name="Sprite" type="Sprite2D" parent="Player"]\n'
+)
+
+SCENE_ADDED_NODE = (
+    '[gd_scene format=3]\n\n'
+    '[node name="Main" type="Node2D"]\n\n'
+    '[node name="Player" type="CharacterBody2D" parent="."]\n\n'
+    '[node name="Sprite" type="Sprite2D" parent="Player"]\n\n'
+    '[node name="Timer" type="Timer" parent="."]\n'
+)
+
+SCENE_REMOVED_NODE = (
+    '[gd_scene format=3]\n\n'
+    '[node name="Main" type="Node2D"]\n\n'
+    '[node name="Player" type="CharacterBody2D" parent="."]\n'
+)
+
+SCENE_MODIFIED_PROP = (
+    '[gd_scene format=3]\n\n'
+    '[node name="Main" type="Node2D"]\n\n'
+    '[node name="Player" type="CharacterBody2D" parent="."]\n'
+    'visible = false\n\n'
+    '[node name="Sprite" type="Sprite2D" parent="Player"]\n'
+)
+
+
+class TestSceneDiff:
+
+    def test_identical_scenes(self, tmp_path: Path) -> None:
+        a = _write_scene(tmp_path / "a.tscn", SCENE_BASE)
+        b = _write_scene(tmp_path / "b.tscn", SCENE_BASE)
+        result = CliRunner().invoke(cli, ["scene", "diff", str(a), str(b)])
+        assert result.exit_code == 0
+        assert "identical" in result.output
+
+    def test_added_node(self, tmp_path: Path) -> None:
+        a = _write_scene(tmp_path / "a.tscn", SCENE_BASE)
+        b = _write_scene(tmp_path / "b.tscn", SCENE_ADDED_NODE)
+        result = CliRunner().invoke(cli, ["scene", "diff", str(a), str(b)])
+        assert result.exit_code == 0
+        assert "+ Timer" in result.output
+
+    def test_removed_node(self, tmp_path: Path) -> None:
+        a = _write_scene(tmp_path / "a.tscn", SCENE_BASE)
+        b = _write_scene(tmp_path / "b.tscn", SCENE_REMOVED_NODE)
+        result = CliRunner().invoke(cli, ["scene", "diff", str(a), str(b)])
+        assert result.exit_code == 0
+        assert "- Player/Sprite" in result.output
+
+    def test_modified_property(self, tmp_path: Path) -> None:
+        a = _write_scene(tmp_path / "a.tscn", SCENE_BASE)
+        b = _write_scene(tmp_path / "b.tscn", SCENE_MODIFIED_PROP)
+        result = CliRunner().invoke(cli, ["scene", "diff", str(a), str(b)])
+        assert result.exit_code == 0
+        assert "~ Player" in result.output
+        assert "visible" in result.output
+
+    def test_json_identical(self, tmp_path: Path) -> None:
+        a = _write_scene(tmp_path / "a.tscn", SCENE_BASE)
+        b = _write_scene(tmp_path / "b.tscn", SCENE_BASE)
+        result = CliRunner().invoke(cli, ["-j", "scene", "diff", str(a), str(b)])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["has_changes"] is False
+
+    def test_json_added_node(self, tmp_path: Path) -> None:
+        a = _write_scene(tmp_path / "a.tscn", SCENE_BASE)
+        b = _write_scene(tmp_path / "b.tscn", SCENE_ADDED_NODE)
+        result = CliRunner().invoke(cli, ["-j", "scene", "diff", str(a), str(b)])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["has_changes"] is True
+        assert len(data["added_nodes"]) == 1
+        assert data["added_nodes"][0]["path"] == "Timer"
+        assert data["added_nodes"][0]["type"] == "Timer"
+
+    def test_json_modified_property(self, tmp_path: Path) -> None:
+        a = _write_scene(tmp_path / "a.tscn", SCENE_BASE)
+        b = _write_scene(tmp_path / "b.tscn", SCENE_MODIFIED_PROP)
+        result = CliRunner().invoke(cli, ["-j", "scene", "diff", str(a), str(b)])
+        data = json.loads(result.output)
+        assert len(data["modified_nodes"]) == 1
+        mod = data["modified_nodes"][0]
+        assert mod["path"] == "Player"
+        assert "visible" in mod["properties"]


### PR DESCRIPTION
## Summary
- Adds `scene diff <a.tscn> <b.tscn>` that structurally compares two scene files
- Reports added nodes (+), removed nodes (-), modified nodes (~) with property-level diffs
- Compares signal connections (added/removed)
- Ignores non-semantic differences (key ordering, formatting)
- JSON output provides full diff data for programmatic use

## Test plan
- [x] All 7 tests pass (`pytest tests/unit/test_scene_diff.py -v`)
- [x] Identical scenes report "structurally identical"
- [x] Added, removed, and modified nodes are correctly detected
- [x] Property changes show old -> new values
- [x] JSON output includes all diff categories

Fixes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)