### PR TITLE
fix: resolve nested parent paths in scene add-node (#119)

### DIFF
--- a/src/auto_godot/commands/particle.py
+++ b/src/auto_godot/commands/particle.py
@@ -12,6 +12,7 @@ from auto_godot.formats.tres import SubResource
 from auto_godot.formats.tscn import (
     SceneNode,
     parse_tscn,
+    resolve_parent_path,
     serialize_tscn,
 )
 from auto_godot.formats.values import Color, SubResourceRef, Vector2
@@ -218,7 +219,7 @@ def add(
         text = path.read_text(encoding="utf-8")
         scene = parse_tscn(text)
 
-        parent = parent_path or "."
+        parent = resolve_parent_path(scene.nodes, parent_path) if parent_path else "."
 
         for node in scene.nodes:
             if node.name == node_name and node.parent == parent:

--- a/src/auto_godot/commands/physics.py
+++ b/src/auto_godot/commands/physics.py
@@ -12,6 +12,7 @@ from auto_godot.formats.tres import SubResource
 from auto_godot.formats.tscn import (
     SceneNode,
     parse_tscn,
+    resolve_parent_path,
     serialize_tscn,
 )
 from auto_godot.formats.values import Vector2
@@ -101,7 +102,7 @@ def add_body(
         text = path.read_text(encoding="utf-8")
         scene = parse_tscn(text)
 
-        parent = parent_path or "."
+        parent = resolve_parent_path(scene.nodes, parent_path) if parent_path else "."
 
         # Check for duplicate
         for node in scene.nodes:

--- a/src/auto_godot/commands/scene.py
+++ b/src/auto_godot/commands/scene.py
@@ -11,7 +11,7 @@ from rich.console import Console
 from rich.tree import Tree
 
 from auto_godot.errors import AutoGodotError, ProjectError, ValidationError
-from auto_godot.formats.tscn import SceneNode, parse_tscn, serialize_tscn, serialize_tscn_file
+from auto_godot.formats.tscn import SceneNode, parse_tscn, resolve_parent_path, serialize_tscn, serialize_tscn_file
 from auto_godot.formats.uid import write_uid_file
 from auto_godot.formats.values import ExtResourceRef, parse_value, serialize_value
 from auto_godot.output import emit, emit_error
@@ -333,7 +333,7 @@ def add_node(
         text = path.read_text(encoding="utf-8")
         scene_data = parse_tscn(text)
 
-        parent = parent_path or "."
+        parent = resolve_parent_path(scene_data.nodes, parent_path) if parent_path else "."
 
         # Check for duplicate
         for node in scene_data.nodes:
@@ -641,7 +641,7 @@ def add_timer(
         text = path_obj.read_text(encoding="utf-8")
         scene_data = parse_tscn(text)
 
-        parent = parent_path or "."
+        parent = resolve_parent_path(scene_data.nodes, parent_path) if parent_path else "."
 
         for node in scene_data.nodes:
             if node.name == node_name and node.parent == parent:
@@ -750,7 +750,7 @@ def add_instance(
         text = path.read_text(encoding="utf-8")
         scene_data = parse_tscn(text)
 
-        parent = parent_path or "."
+        parent = resolve_parent_path(scene_data.nodes, parent_path) if parent_path else "."
 
         for node in scene_data.nodes:
             if node.name == node_name and node.parent == parent:
@@ -955,7 +955,7 @@ def add_camera(
         path_obj = Path(scene_path)
         text = path_obj.read_text(encoding="utf-8")
         scene_data = parse_tscn(text)
-        parent = parent_path or "."
+        parent = resolve_parent_path(scene_data.nodes, parent_path) if parent_path else "."
 
         for node in scene_data.nodes:
             if node.name == node_name and node.parent == parent:

--- a/src/auto_godot/formats/tscn.py
+++ b/src/auto_godot/formats/tscn.py
@@ -45,6 +45,23 @@ class SceneNode:
     raw_section: Section | None = None
 
 
+def resolve_parent_path(nodes: list[SceneNode], parent_name: str) -> str:
+    """Resolve a bare node name to its full path from the scene root.
+
+    If parent_name already contains '/' or is '.', return it as-is.
+    Otherwise search existing nodes for the name and build the full
+    path by prepending the matched node's own parent path.
+    """
+    if "/" in parent_name or parent_name == ".":
+        return parent_name
+    for node in nodes:
+        if node.name == parent_name:
+            if node.parent is None or node.parent == ".":
+                return parent_name
+            return f"{node.parent}/{parent_name}"
+    return parent_name
+
+
 @dataclass
 class Connection:
     """A [connection] section."""

--- a/tests/unit/test_scene_node_commands.py
+++ b/tests/unit/test_scene_node_commands.py
@@ -57,6 +57,38 @@ class TestAddNode:
         text = scene.read_text()
         assert 'parent="Player"' in text
 
+    def test_add_with_nested_parent(self, tmp_path: Path) -> None:
+        """Bare --parent resolves nested node to full path from root."""
+        scene = _make_scene(tmp_path)
+        runner = CliRunner()
+        # Sprite is at parent="Player", so a child of Sprite needs
+        # parent="Player/Sprite" in the .tscn file.
+        result = runner.invoke(cli, [
+            "scene", "add-node",
+            "--scene", str(scene),
+            "--name", "SpriteChild",
+            "--type", "Node2D",
+            "--parent", "Sprite",
+        ])
+        assert result.exit_code == 0, result.output
+        text = scene.read_text()
+        assert 'parent="Player/Sprite"' in text
+
+    def test_add_with_full_path_parent(self, tmp_path: Path) -> None:
+        """Full path --parent is used as-is without resolution."""
+        scene = _make_scene(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "scene", "add-node",
+            "--scene", str(scene),
+            "--name", "SpriteChild",
+            "--type", "Node2D",
+            "--parent", "Player/Sprite",
+        ])
+        assert result.exit_code == 0, result.output
+        text = scene.read_text()
+        assert 'parent="Player/Sprite"' in text
+
     def test_add_with_properties(self, tmp_path: Path) -> None:
         scene = _make_scene(tmp_path)
         runner = CliRunner()


### PR DESCRIPTION
## Summary
- When `--parent` takes a bare node name (e.g., `Sprite`), resolves it to the full NodePath from root (e.g., `Player/Sprite`) by searching the existing scene tree
- Fixed in `scene add-node`, `add-timer`, `add-instance`, `add-camera`, `particle add`, and `physics add-body`
- Added `resolve_parent_path()` to `formats/tscn.py` as a shared utility

## Test plan
- [x] New test: `test_add_with_nested_parent` verifies bare name resolves to full path
- [x] New test: `test_add_with_full_path_parent` verifies explicit paths pass through unchanged
- [x] All 1476 unit tests pass (2 new)

Fixes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)