### PR TITLE
fix: default sprite export to --no-trim, warn on non-uniform frames (#111)

### DIFF
--- a/src/auto_godot/commands/sprite.py
+++ b/src/auto_godot/commands/sprite.py
@@ -152,6 +152,17 @@ def _do_import_aseprite(
             "will have no animation data"
         )
 
+    # Warn when frames have non-uniform sizes (causes animation jitter)
+    if len(aseprite_data.frames) > 1:
+        sizes = {(f.frame.w, f.frame.h) for f in aseprite_data.frames}
+        if len(sizes) > 1:
+            size_list = ", ".join(f"{w}x{h}" for w, h in sorted(sizes))
+            warnings_list.append(
+                f"Frames have non-uniform sizes ({size_list}); "
+                "this may cause animation jitter. "
+                "Re-export with --no-trim to fix."
+            )
+
     image_res_path = _resolve_image_path(
         res_path, aseprite_data.meta.image, output,
     )
@@ -293,11 +304,8 @@ def _print_import_result(data: dict[str, Any], verbose: bool = False) -> None:
     frames = data["frame_count"]
     click.echo(f"Created {output} with {anims} animation(s) ({frames} frames)")
     if data.get("warnings"):
-        click.echo(
-            f"  Warning: {len(data['warnings'])} animation(s) skipped"
-            " due to errors",
-            err=True,
-        )
+        for warning in data["warnings"]:
+            click.echo(f"  Warning: {warning}", err=True)
 
 
 def _emit_result(
@@ -824,7 +832,7 @@ _DEFAULT_ASEPRITE = r"C:\Program Files (x86)\Steam\steamapps\common\Aseprite\Ase
               help="Path to Aseprite binary. Default: ASEPRITE_PATH env or standard install.")
 @click.option("--sheet-type", type=click.Choice(["packed", "rows", "horizontal", "vertical"]),
               default="packed", help="Sprite sheet layout (default: packed).")
-@click.option("--trim/--no-trim", default=True, help="Trim transparent pixels (default: yes).")
+@click.option("--trim/--no-trim", default=False, help="Trim transparent pixels (default: no). Trimming can cause animation jitter from non-uniform frame sizes.")
 @click.option("--import-tres/--no-import-tres", "do_import", default=True,
               help="Also generate SpriteFrames .tres (default: yes).")
 @click.pass_context

--- a/tests/unit/test_sprite_import_command.py
+++ b/tests/unit/test_sprite_import_command.py
@@ -345,3 +345,50 @@ class TestImportAsepritePartialFailure:
             ["sprite", "import-aseprite", str(fixture), "-o", str(output)],
         )
         assert result.exit_code != 0
+
+
+class TestImportNonUniformFrameWarning:
+    """Verify warning when frames have different sizes."""
+
+    def test_non_uniform_frames_emit_warning(self, tmp_path: Path) -> None:
+        fixture = tmp_path / "non_uniform.json"
+        fixture.write_text(json.dumps({
+            "frames": [
+                {
+                    "filename": "frame 0",
+                    "frame": {"x": 0, "y": 0, "w": 8, "h": 13},
+                    "rotated": False,
+                    "trimmed": True,
+                    "spriteSourceSize": {"x": 0, "y": 0, "w": 8, "h": 13},
+                    "sourceSize": {"w": 8, "h": 16},
+                    "duration": 100,
+                },
+                {
+                    "filename": "frame 1",
+                    "frame": {"x": 8, "y": 0, "w": 8, "h": 14},
+                    "rotated": False,
+                    "trimmed": True,
+                    "spriteSourceSize": {"x": 0, "y": 0, "w": 8, "h": 14},
+                    "sourceSize": {"w": 8, "h": 16},
+                    "duration": 100,
+                },
+            ],
+            "meta": {
+                "app": "test",
+                "version": "1.0",
+                "image": "sheet.png",
+                "format": "RGBA8888",
+                "size": {"w": 16, "h": 16},
+                "scale": "1",
+                "frameTags": [],
+            },
+        }))
+        output = tmp_path / "non_uniform.tres"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["sprite", "import-aseprite", str(fixture), "-o", str(output)],
+        )
+        assert result.exit_code == 0
+        combined = result.output + (result.stderr_bytes or b"").decode()
+        assert "non-uniform" in combined.lower()


### PR DESCRIPTION
## Summary
- Changed `sprite export --trim` default from `true` to `false` to prevent animation jitter from non-uniform frame sizes
- Added detection in `import-aseprite` that warns when frames have different dimensions (e.g., "8x13, 8x14")
- Improved warning output to show individual messages instead of a generic count

## Test plan
- [x] New test: `test_non_uniform_frames_emit_warning` verifies the jitter warning is emitted
- [x] All 1475 unit tests pass (1 new)
- [x] Existing trimmed-frame tests continue to pass

Fixes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)