### PR TITLE
fix: count actual frames in texturepacker JSON output (#124)

### DIFF
--- a/src/auto_godot/commands/sprite.py
+++ b/src/auto_godot/commands/sprite.py
@@ -430,7 +430,7 @@ def import_texturepacker(
         data: dict[str, Any] = {
             "output_path": str(output_path),
             "animation_count": len(animations),
-            "frame_count": len(all_sub_resources),
+            "frame_count": sum(len(fs) for fs in groups.values()),
             "image_path": image_res_path,
             "animations": [str(a.get("name", "")) for a in animations],
             "warnings": [],

--- a/tests/unit/test_texturepacker_import.py
+++ b/tests/unit/test_texturepacker_import.py
@@ -119,6 +119,20 @@ class TestImportTexturePackerCommand:
         assert data["animation_count"] == 2
         assert data["frame_count"] == 4
 
+    def test_frame_count_matches_actual_frames(self, tmp_path: Path) -> None:
+        """frame_count must reflect actual frames, not sub-resource count."""
+        out = tmp_path / "result.tres"
+        result = CliRunner().invoke(cli, [
+            "-j", "sprite", "import-texturepacker", str(FIXTURE), "-o", str(out),
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        # Fixture has 2 idle frames + 2 run frames = 4 total
+        frames, _ = parse_texturepacker_json(FIXTURE)
+        groups = group_frames_by_animation(frames)
+        expected = sum(len(fs) for fs in groups.values())
+        assert data["frame_count"] == expected
+
     def test_custom_fps(self, tmp_path: Path) -> None:
         out = tmp_path / "result.tres"
         result = CliRunner().invoke(cli, [


### PR DESCRIPTION
## Summary

- Changed `frame_count` in `sprite import-texturepacker` JSON output to derive from actual frame groups (`sum(len(fs) for fs in groups.values())`) instead of `len(all_sub_resources)`
- Added test that validates frame_count matches the sum of per-animation frame counts from the parser
- Current behavior is unchanged (1:1 mapping between frames and sub-resources), but the fix makes intent explicit and is resilient to future sub-resource types

Fixes #124

## Test plan

- [x] Existing 14 texturepacker tests pass
- [x] New `test_frame_count_matches_actual_frames` validates count against parser groups
- [x] Full sync unit suite passes (1418 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)