### PR TITLE
fix: strip root node name from parent paths in scene add-node (#125)

### DIFF
--- a/src/auto_godot/formats/tscn.py
+++ b/src/auto_godot/formats/tscn.py
@@ -48,15 +48,33 @@ class SceneNode:
 def resolve_parent_path(nodes: list[SceneNode], parent_name: str) -> str:
     """Resolve a bare node name to its full path from the scene root.
 
-    If parent_name already contains '/' or is '.', return it as-is.
-    Otherwise search existing nodes for the name and build the full
-    path by prepending the matched node's own parent path.
+    Godot .tscn parent paths are relative to the root node: direct
+    children use ``parent="."``, grandchildren use ``parent="Child"``,
+    etc.  The root node name must never appear in a parent path.
     """
-    if "/" in parent_name or parent_name == ".":
+    if parent_name == ".":
         return parent_name
+
+    # Identify the root node so we can strip its name from paths.
+    root_name: str | None = None
+    for node in nodes:
+        if node.parent is None:
+            root_name = node.name
+            break
+
+    # Paths containing '/': strip leading root name if present.
+    if "/" in parent_name:
+        if root_name is not None and parent_name.startswith(f"{root_name}/"):
+            return parent_name[len(root_name) + 1:]
+        return parent_name
+
+    # Bare name: if it matches the root node, the caller wants a
+    # direct child of root, which is "." in .tscn format.
     for node in nodes:
         if node.name == parent_name:
-            if node.parent is None or node.parent == ".":
+            if node.parent is None:
+                return "."
+            if node.parent == ".":
                 return parent_name
             return f"{node.parent}/{parent_name}"
     return parent_name

--- a/tests/unit/test_scene_node_commands.py
+++ b/tests/unit/test_scene_node_commands.py
@@ -89,6 +89,39 @@ class TestAddNode:
         text = scene.read_text()
         assert 'parent="Player/Sprite"' in text
 
+    def test_add_with_root_parent(self, tmp_path: Path) -> None:
+        """--parent RootName resolves to '.' in the .tscn file."""
+        scene = _make_scene(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "scene", "add-node",
+            "--scene", str(scene),
+            "--name", "Timer",
+            "--type", "Timer",
+            "--parent", "Main",
+        ])
+        assert result.exit_code == 0, result.output
+        text = scene.read_text()
+        assert 'name="Timer"' in text
+        assert 'parent="."' in text
+        assert 'parent="Main"' not in text
+
+    def test_add_with_root_prefixed_path(self, tmp_path: Path) -> None:
+        """--parent RootName/Child strips root and resolves to 'Child'."""
+        scene = _make_scene(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "scene", "add-node",
+            "--scene", str(scene),
+            "--name", "SpriteChild",
+            "--type", "Node2D",
+            "--parent", "Main/Player",
+        ])
+        assert result.exit_code == 0, result.output
+        text = scene.read_text()
+        assert 'parent="Player"' in text
+        assert 'parent="Main/Player"' not in text
+
     def test_add_with_properties(self, tmp_path: Path) -> None:
         scene = _make_scene(tmp_path)
         runner = CliRunner()


### PR DESCRIPTION
## Summary

- `resolve_parent_path()` now returns `"."` when the user passes the root node name as `--parent` (e.g., `--parent Game` where Game is the root)
- Strips root name prefix from compound paths (e.g., `--parent Game/VBox` resolves to `VBox` instead of `Game/VBox`)
- Adds two new tests covering both cases

Fixes #125

## Test plan

- [x] `test_add_with_root_parent`: `--parent Main` -> `parent="."` in .tscn
- [x] `test_add_with_root_prefixed_path`: `--parent Main/Player` -> `parent="Player"` in .tscn
- [x] All existing 21 scene node tests pass
- [x] Full unit suite: 1493 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)