### PR TITLE
fix: validate fps > 0 before division in import-texturepacker (#123)

### DIFF
--- a/src/auto_godot/formats/texturepacker.py
+++ b/src/auto_godot/formats/texturepacker.py
@@ -61,6 +61,12 @@ def parse_texturepacker_json(
             fix="Export from TexturePacker with JSON data format",
         )
 
+    if fps <= 0:
+        raise ValidationError(
+            message="fps must be greater than zero",
+            code="TEXTUREPACKER_INVALID_FPS",
+            fix="Pass a positive --fps value, e.g. --fps 10",
+        )
     duration_ms = max(1, int(1000.0 / fps))
     frames: list[AsepriteFrame] = []
 

--- a/tests/unit/test_texturepacker_import.py
+++ b/tests/unit/test_texturepacker_import.py
@@ -129,6 +129,16 @@ class TestImportTexturePackerCommand:
         data = json.loads(result.output)
         assert data["animation_count"] == 2
 
+    def test_fps_zero_error(self, tmp_path: Path) -> None:
+        """--fps 0 must produce an actionable error, not ZeroDivisionError."""
+        out = tmp_path / "result.tres"
+        result = CliRunner().invoke(cli, [
+            "-j", "sprite", "import-texturepacker", str(FIXTURE),
+            "-o", str(out), "--fps", "0",
+        ])
+        assert result.exit_code != 0
+        assert "fps must be greater than zero" in result.output
+
     def test_default_output_path(self) -> None:
         result = CliRunner().invoke(cli, [
             "-j", "sprite", "import-texturepacker", str(FIXTURE),


### PR DESCRIPTION
## Summary

- Added a guard in `parse_texturepacker_json()` that raises `ValidationError` when `fps <= 0`, preventing `ZeroDivisionError` at the `1000.0 / fps` division
- Error message includes actionable fix suggestion: "Pass a positive --fps value, e.g. --fps 10"
- Added regression test confirming `--fps 0` returns exit code 1 with the error message

Fixes #123

## Test plan

- [x] `test_fps_zero_error`: `--fps 0` -> exit code 1, "fps must be greater than zero"
- [x] All 15 texturepacker tests pass
- [x] Full unit suite: 1492 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)