### PR TITLE
feat: add --dry-run flag for previewing file changes (#110)

### DIFF
--- a/src/auto_godot/cli.py
+++ b/src/auto_godot/cli.py
@@ -88,8 +88,29 @@ def cli(
         godot_path=godot_path,
     )
 
+    if dry_run:
+        ctx.call_on_close(lambda: _warn_if_dry_run_unacknowledged(ctx))
+
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
+
+
+def _warn_if_dry_run_unacknowledged(ctx: click.Context) -> None:
+    """Warn users when --dry-run was set but no maybe_write() was called.
+
+    Closes the data-safety trap where commands outside scene group silently
+    write files despite the flag. Supported commands call maybe_write()
+    which sets dry_run_acknowledged=True. If the flag remains False after
+    the command runs, no write was intercepted and the user may have
+    unintentionally modified files.
+    """
+    config: GlobalConfig = ctx.obj
+    if config.dry_run and not config.dry_run_acknowledged:
+        sys.stderr.write(
+            "Warning: --dry-run is not yet implemented for this command.\n"
+            "Files may have been written. See issue #110 for supported "
+            "commands.\n"
+        )
 
 
 @click.command("import")

--- a/src/auto_godot/cli.py
+++ b/src/auto_godot/cli.py
@@ -52,6 +52,7 @@ from auto_godot.output import GlobalConfig, emit, emit_error
 @click.option("-v", "--verbose", is_flag=True, help="Show extra detail.")
 @click.option("-q", "--quiet", is_flag=True, help="Suppress all output except errors.")
 @click.option("--no-color", is_flag=True, help="Disable colored output.")
+@click.option("--dry-run", is_flag=True, help="Preview changes without writing files.")
 @click.option(
     "--godot-path",
     type=click.Path(),
@@ -66,6 +67,7 @@ def cli(
     verbose: bool,
     quiet: bool,
     no_color: bool,
+    dry_run: bool,
     godot_path: str | None,
 ) -> None:
     """auto-godot: Agent-native CLI for Godot Engine (Godot 4.5+).
@@ -82,6 +84,7 @@ def cli(
         json_mode=json_mode,
         verbose=verbose,
         quiet=quiet,
+        dry_run=dry_run,
         godot_path=godot_path,
     )
 

--- a/src/auto_godot/commands/scene.py
+++ b/src/auto_godot/commands/scene.py
@@ -11,10 +11,10 @@ from rich.console import Console
 from rich.tree import Tree
 
 from auto_godot.errors import AutoGodotError, ProjectError, ValidationError
-from auto_godot.formats.tscn import SceneNode, parse_tscn, resolve_parent_path, serialize_tscn, serialize_tscn_file
+from auto_godot.formats.tscn import SceneNode, parse_tscn, resolve_parent_path, serialize_tscn
 from auto_godot.formats.uid import write_uid_file
 from auto_godot.formats.values import ExtResourceRef, parse_value, serialize_value
-from auto_godot.output import emit, emit_error
+from auto_godot.output import emit, emit_error, maybe_write
 from auto_godot.scene.builder import build_scene
 from auto_godot.scene.lister import list_scenes
 
@@ -193,9 +193,9 @@ def scene_create(ctx: click.Context, json_file: str, output: str | None) -> None
         return
 
     output_path = _resolve_scene_output(output, json_path)
-    serialize_tscn_file(gd_scene, output_path)
+    maybe_write(ctx, output_path, serialize_tscn(gd_scene))
 
-    if gd_scene.uid:
+    if gd_scene.uid and not ctx.obj.dry_run:
         write_uid_file(output_path, gd_scene.uid)
 
     def _human(data: dict[str, Any], verbose: bool = False) -> None:
@@ -240,10 +240,11 @@ def create_simple(
         }
         gd_scene = build_scene(definition)
         output_path = Path(output)
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        serialize_tscn_file(gd_scene, output_path)
+        if not ctx.obj.dry_run:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+        maybe_write(ctx, output_path, serialize_tscn(gd_scene))
 
-        if gd_scene.uid:
+        if gd_scene.uid and not ctx.obj.dry_run:
             write_uid_file(output_path, gd_scene.uid)
 
         data = {"path": str(output_path), "root_type": root_type, "root_name": root_name}
@@ -366,7 +367,7 @@ def add_node(
         scene_data._raw_header = None
         scene_data._raw_sections = None
         output = serialize_tscn(scene_data)
-        path.write_text(output, encoding="utf-8")
+        maybe_write(ctx, path, output)
 
         data = {
             "added": True,
@@ -482,7 +483,7 @@ def remove_node(
         scene_data._raw_header = None
         scene_data._raw_sections = None
         output = serialize_tscn(scene_data)
-        path.write_text(output, encoding="utf-8")
+        maybe_write(ctx, path, output)
 
         data = {
             "removed": True,
@@ -580,7 +581,7 @@ def set_property(
         scene_data._raw_header = None
         scene_data._raw_sections = None
         output = serialize_tscn(scene_data)
-        path.write_text(output, encoding="utf-8")
+        maybe_write(ctx, path, output)
 
         data = {
             "updated": True,
@@ -676,7 +677,7 @@ def add_timer(
         scene_data._raw_header = None
         scene_data._raw_sections = None
         output = serialize_tscn(scene_data)
-        path_obj.write_text(output, encoding="utf-8")
+        maybe_write(ctx, path_obj, output)
 
         data = {
             "added": True,
@@ -802,7 +803,7 @@ def add_instance(
         scene_data._raw_header = None
         scene_data._raw_sections = None
         output = serialize_tscn(scene_data)
-        path.write_text(output, encoding="utf-8")
+        maybe_write(ctx, path, output)
 
         data = {
             "added": True,
@@ -891,7 +892,7 @@ def add_group(
         scene_data._raw_header = None
         scene_data._raw_sections = None
         output = serialize_tscn(scene_data)
-        path.write_text(output, encoding="utf-8")
+        maybe_write(ctx, path, output)
 
         data = {
             "updated": True,
@@ -992,7 +993,7 @@ def add_camera(
         scene_data._raw_header = None
         scene_data._raw_sections = None
         output = serialize_tscn(scene_data)
-        path_obj.write_text(output, encoding="utf-8")
+        maybe_write(ctx, path_obj, output)
 
         data = {
             "added": True,
@@ -1100,7 +1101,7 @@ def duplicate_node(
         scene_data._raw_header = None
         scene_data._raw_sections = None
         output = serialize_tscn(scene_data)
-        path_obj.write_text(output, encoding="utf-8")
+        maybe_write(ctx, path_obj, output)
 
         data = {
             "duplicated": True,
@@ -1306,7 +1307,7 @@ def rename_node(
 
         scene_data._raw_header = None
         scene_data._raw_sections = None
-        path.write_text(serialize_tscn(scene_data), encoding="utf-8")
+        maybe_write(ctx, path, serialize_tscn(scene_data))
 
         data = {"renamed": True, "old_name": old_name, "new_name": new_name, "scene": scene_path}
 
@@ -1394,7 +1395,7 @@ def reorder_node(
 
         scene_data._raw_header = None
         scene_data._raw_sections = None
-        path.write_text(serialize_tscn(scene_data), encoding="utf-8")
+        maybe_write(ctx, path, serialize_tscn(scene_data))
 
         data = {"reordered": True, "name": node_name, "index": target_index, "scene": scene_path}
 
@@ -1487,7 +1488,7 @@ def set_resource(
 
         scene_data._raw_header = None
         scene_data._raw_sections = None
-        path.write_text(serialize_tscn(scene_data), encoding="utf-8")
+        maybe_write(ctx, path, serialize_tscn(scene_data))
 
         data = {
             "set": True,
@@ -1639,7 +1640,7 @@ def move_node(
 
         scene_data._raw_header = None
         scene_data._raw_sections = None
-        path.write_text(serialize_tscn(scene_data), encoding="utf-8")
+        maybe_write(ctx, path, serialize_tscn(scene_data))
 
         data = {"moved": True, "name": node_name, "from": old_parent, "to": new_parent, "scene": scene_path}
 
@@ -1756,7 +1757,7 @@ def copy_properties(
 
         scene_data._raw_header = None
         scene_data._raw_sections = None
-        path.write_text(serialize_tscn(scene_data), encoding="utf-8")
+        maybe_write(ctx, path, serialize_tscn(scene_data))
 
         data = {"copied": copied, "from": from_node, "to": to_node, "scene": scene_path}
 
@@ -1832,7 +1833,7 @@ def set_anchor(
 
         scene_data._raw_header = None
         scene_data._raw_sections = None
-        path.write_text(serialize_tscn(scene_data), encoding="utf-8")
+        maybe_write(ctx, path, serialize_tscn(scene_data))
 
         data = {"set": True, "node": node_name, "preset": preset, "scene": scene_path}
 
@@ -1919,10 +1920,11 @@ def from_template(
 
         gd_scene = build_scene(definition)
         output_path = Path(output)
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        serialize_tscn_file(gd_scene, output_path)
+        if not ctx.obj.dry_run:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+        maybe_write(ctx, output_path, serialize_tscn(gd_scene))
 
-        if gd_scene.uid:
+        if gd_scene.uid and not ctx.obj.dry_run:
             write_uid_file(output_path, gd_scene.uid)
 
         data = {"path": str(output_path), "template": template}

--- a/src/auto_godot/output.py
+++ b/src/auto_godot/output.py
@@ -32,6 +32,7 @@ class GlobalConfig:
     verbose: bool = field(default=False)
     quiet: bool = field(default=False)
     dry_run: bool = field(default=False)
+    dry_run_acknowledged: bool = field(default=False)
     godot_path: str | None = field(default=None)
 
 
@@ -74,6 +75,7 @@ def maybe_write(
                 f"[dry-run] Would {action}: {file_path} "
                 f"({len(content)} bytes)\n"
             )
+        config.dry_run_acknowledged = True
         return False
     file_path.write_text(content, encoding="utf-8")
     return True

--- a/src/auto_godot/output.py
+++ b/src/auto_godot/output.py
@@ -31,6 +31,7 @@ class GlobalConfig:
     json_mode: bool = field(default=False)
     verbose: bool = field(default=False)
     quiet: bool = field(default=False)
+    dry_run: bool = field(default=False)
     godot_path: str | None = field(default=None)
 
 
@@ -49,6 +50,33 @@ def emit(
         sys.stdout.write(json.dumps(data, indent=2) + "\n")
     elif not config.quiet:
         human_fn(data, verbose=config.verbose)
+
+
+def maybe_write(
+    ctx: click.Context | Any,
+    path: Any,
+    content: str,
+) -> bool:
+    """Write content to path unless dry_run is active.
+
+    Returns True if the file was written, False if skipped (dry-run).
+    In dry-run mode, emits a preview message to stderr.
+    """
+    from pathlib import Path as _Path
+
+    config: GlobalConfig = ctx.obj
+    file_path = _Path(path)
+    if config.dry_run:
+        exists = file_path.exists()
+        action = "overwrite" if exists else "create"
+        if not config.json_mode and not config.quiet:
+            sys.stderr.write(
+                f"[dry-run] Would {action}: {file_path} "
+                f"({len(content)} bytes)\n"
+            )
+        return False
+    file_path.write_text(content, encoding="utf-8")
+    return True
 
 
 def emit_error(error: AutoGodotError, ctx: click.Context | Any) -> None:

--- a/tests/unit/test_dry_run.py
+++ b/tests/unit/test_dry_run.py
@@ -142,3 +142,37 @@ class TestDryRunWithoutFlag:
         assert result.exit_code == 0
         assert out.exists()
         assert "Node2D" in out.read_text()
+
+
+class TestDryRunSafetyGuard:
+    """Unsupported commands must warn users that --dry-run had no effect."""
+
+    def test_unsupported_command_emits_warning(self, tmp_path: Path) -> None:
+        """script create does not yet honor --dry-run, so warning must fire."""
+        out = tmp_path / "test.gd"
+        result = CliRunner().invoke(cli, [
+            "--dry-run", "script", "create",
+            "--extends", "Node", str(out),
+        ])
+        # Warning fired because script create still writes directly.
+        assert "--dry-run is not yet implemented" in result.output
+        assert "Files may have been written" in result.output
+
+    def test_supported_command_no_warning(self, tmp_path: Path) -> None:
+        """scene create-simple honors --dry-run, so no warning."""
+        out = tmp_path / "level.tscn"
+        result = CliRunner().invoke(cli, [
+            "--dry-run", "scene", "create-simple",
+            "--root-type", "Node2D", "--root-name", "Level",
+            "-o", str(out),
+        ])
+        assert result.exit_code == 0
+        assert "--dry-run is not yet implemented" not in result.output
+
+    def test_no_warning_without_dry_run(self, tmp_path: Path) -> None:
+        """Warning must not fire when --dry-run was not passed."""
+        out = tmp_path / "test.gd"
+        result = CliRunner().invoke(cli, [
+            "script", "create", "--extends", "Node", str(out),
+        ])
+        assert "--dry-run is not yet implemented" not in result.output

--- a/tests/unit/test_dry_run.py
+++ b/tests/unit/test_dry_run.py
@@ -1,0 +1,144 @@
+"""Tests for --dry-run global flag."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from auto_godot.cli import cli
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures"
+FIXTURE_SCENE_DEF = str(FIXTURES_DIR / "scene_definition.json")
+
+SAMPLE_TSCN = """\
+[gd_scene format=3]
+
+[node name="Root" type="Node2D"]
+"""
+
+
+class TestDryRunSceneCreate:
+    """--dry-run should skip file writes for scene create commands."""
+
+    def test_create_simple_no_file_written(self, tmp_path: Path) -> None:
+        out = tmp_path / "level.tscn"
+        result = CliRunner().invoke(cli, [
+            "--dry-run", "scene", "create-simple",
+            "--root-type", "Node2D", "--root-name", "Level",
+            "-o", str(out),
+        ])
+        assert result.exit_code == 0, result.output
+        assert not out.exists(), "File should not be created in dry-run mode"
+        assert "[dry-run]" in result.output
+
+    def test_create_simple_still_emits_output(self, tmp_path: Path) -> None:
+        out = tmp_path / "level.tscn"
+        result = CliRunner().invoke(cli, [
+            "--dry-run", "scene", "create-simple",
+            "--root-type", "Node2D", "--root-name", "Level",
+            "-o", str(out),
+        ])
+        assert result.exit_code == 0
+        assert "Created scene" in result.output
+
+    def test_create_simple_json_output(self, tmp_path: Path) -> None:
+        out = tmp_path / "level.tscn"
+        result = CliRunner().invoke(cli, [
+            "--dry-run", "-j", "scene", "create-simple",
+            "--root-type", "Node2D", "--root-name", "Level",
+            "-o", str(out),
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["root_type"] == "Node2D"
+        assert not out.exists()
+
+    def test_create_from_json_no_file_written(self, tmp_path: Path) -> None:
+        out = tmp_path / "scene.tscn"
+        result = CliRunner().invoke(cli, [
+            "--dry-run", "scene", "create", FIXTURE_SCENE_DEF,
+            "-o", str(out),
+        ])
+        assert result.exit_code == 0, result.output
+        assert not out.exists()
+        assert "[dry-run]" in result.output
+
+
+class TestDryRunSceneModify:
+    """--dry-run should skip file writes for scene modification commands."""
+
+    def test_add_node_no_write(self, tmp_path: Path) -> None:
+        scene_file = tmp_path / "test.tscn"
+        scene_file.write_text(SAMPLE_TSCN)
+        original = scene_file.read_text()
+
+        result = CliRunner().invoke(cli, [
+            "--dry-run", "scene", "add-node",
+            "--scene", str(scene_file),
+            "--name", "Timer", "--type", "Timer",
+        ])
+        assert result.exit_code == 0, result.output
+        assert scene_file.read_text() == original, "File should not be modified"
+        assert "[dry-run]" in result.output
+
+    def test_add_node_still_emits_data(self, tmp_path: Path) -> None:
+        scene_file = tmp_path / "test.tscn"
+        scene_file.write_text(SAMPLE_TSCN)
+
+        result = CliRunner().invoke(cli, [
+            "--dry-run", "-j", "scene", "add-node",
+            "--scene", str(scene_file),
+            "--name", "Timer", "--type", "Timer",
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["added"] is True
+        assert data["name"] == "Timer"
+
+    def test_set_property_no_write(self, tmp_path: Path) -> None:
+        scene_file = tmp_path / "test.tscn"
+        scene_file.write_text(SAMPLE_TSCN)
+        original = scene_file.read_text()
+
+        result = CliRunner().invoke(cli, [
+            "--dry-run", "scene", "set-property",
+            "--scene", str(scene_file),
+            "--node", "Root", "--property", "visible=false",
+        ])
+        assert result.exit_code == 0, result.output
+        assert scene_file.read_text() == original
+
+    def test_remove_node_no_write(self, tmp_path: Path) -> None:
+        tscn = (
+            '[gd_scene format=3]\n\n'
+            '[node name="Root" type="Node2D"]\n\n'
+            '[node name="Child" type="Sprite2D" parent="."]\n'
+        )
+        scene_file = tmp_path / "test.tscn"
+        scene_file.write_text(tscn)
+        original = scene_file.read_text()
+
+        result = CliRunner().invoke(cli, [
+            "--dry-run", "scene", "remove-node",
+            "--scene", str(scene_file),
+            "--name", "Child",
+        ])
+        assert result.exit_code == 0, result.output
+        assert scene_file.read_text() == original
+
+
+class TestDryRunWithoutFlag:
+    """Normal operation (no --dry-run) should still write files."""
+
+    def test_create_simple_writes_normally(self, tmp_path: Path) -> None:
+        out = tmp_path / "level.tscn"
+        result = CliRunner().invoke(cli, [
+            "scene", "create-simple",
+            "--root-type", "Node2D", "--root-name", "Level",
+            "-o", str(out),
+        ])
+        assert result.exit_code == 0
+        assert out.exists()
+        assert "Node2D" in out.read_text()


### PR DESCRIPTION
## Summary

- Added `--dry-run` global flag that skips all file writes while still running parsing, validation, and output emission
- New `maybe_write()` helper in `output.py` centralizes the write-or-skip logic with `[dry-run]` preview messages on stderr
- All 17 scene command write points are wired up; other command groups can adopt the same helper in follow-up PRs
- Agent workflows can now verify a plan before executing: `auto-godot --dry-run scene add-node ...`

Fixes #110

## Test plan

- [x] 9 new tests in `test_dry_run.py` covering create, add-node, set-property, remove-node
- [x] Tests verify files are not created/modified in dry-run mode
- [x] Tests verify normal output (human and JSON) is still emitted
- [x] Tests verify normal operation without `--dry-run` still writes files
- [x] All 82 existing scene tests pass (zero regressions)

## Scope

This PR covers scene commands only. Follow-up PRs will wire `maybe_write` into sprite, tileset, script, and other command groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)