### PR TITLE
feat: add scene lint command for node property validation (#106)

### DIFF
--- a/src/auto_godot/commands/scene.py
+++ b/src/auto_godot/commands/scene.py
@@ -2144,3 +2144,97 @@ def validate_scene(ctx: click.Context, scene_path: str) -> None:
             ),
             ctx,
         )
+
+
+# ---------------------------------------------------------------------------
+# scene lint
+# ---------------------------------------------------------------------------
+
+# Maps node types to required properties and human-readable warnings.
+_LINT_RULES: dict[str, list[tuple[str, str]]] = {
+    "Sprite2D": [("texture", "invisible without a texture")],
+    "Sprite3D": [("texture", "invisible without a texture")],
+    "AnimatedSprite2D": [("sprite_frames", "invisible without SpriteFrames")],
+    "AnimatedSprite3D": [("sprite_frames", "invisible without SpriteFrames")],
+    "TextureRect": [("texture", "invisible without a texture")],
+    "TextureButton": [("texture_normal", "invisible without a normal texture")],
+    "CollisionShape2D": [("shape", "has no effect without a shape")],
+    "CollisionShape3D": [("shape", "has no effect without a shape")],
+    "CollisionPolygon2D": [("polygon", "has no effect without a polygon")],
+    "AudioStreamPlayer": [("stream", "silent without a stream resource")],
+    "AudioStreamPlayer2D": [("stream", "silent without a stream resource")],
+    "AudioStreamPlayer3D": [("stream", "silent without a stream resource")],
+    "CPUParticles2D": [("texture", "invisible without a texture")],
+    "MeshInstance3D": [("mesh", "invisible without a mesh")],
+    "NavigationRegion2D": [("navigation_polygon", "has no effect without a polygon")],
+    "VideoStreamPlayer": [("stream", "silent without a stream")],
+}
+
+
+def _lint_node(node: SceneNode) -> list[dict[str, str]]:
+    """Check a single node against lint rules. Returns list of warnings."""
+    if node.type is None or node.type not in _LINT_RULES:
+        return []
+    warnings: list[dict[str, str]] = []
+    for prop, reason in _LINT_RULES[node.type]:
+        if prop not in node.properties:
+            warnings.append({
+                "node": node.name,
+                "type": node.type,
+                "property": prop,
+                "message": f"{node.type} '{node.name}' is {reason}",
+            })
+    return warnings
+
+
+@scene.command("lint")
+@click.argument("scene_path", type=click.Path(exists=True))
+@click.pass_context
+def lint_scene(ctx: click.Context, scene_path: str) -> None:
+    """Check nodes for commonly-missing required properties.
+
+    Warns when nodes are likely non-functional: invisible sprites without
+    textures, collision shapes without shapes, audio players without
+    streams, etc.
+
+    Examples:
+
+      auto-godot scene lint scenes/main.tscn
+
+      auto-godot --json scene lint scenes/player.tscn
+    """
+    try:
+        path = Path(scene_path)
+        text = path.read_text(encoding="utf-8")
+        scene_data = parse_tscn(text)
+
+        all_warnings: list[dict[str, str]] = []
+        for node in scene_data.nodes:
+            all_warnings.extend(_lint_node(node))
+
+        data: dict[str, Any] = {
+            "scene": scene_path,
+            "node_count": len(scene_data.nodes),
+            "warning_count": len(all_warnings),
+            "warnings": all_warnings,
+        }
+
+        def _human(data: dict[str, Any], verbose: bool = False) -> None:
+            count = data["warning_count"]
+            if count == 0:
+                click.echo(f"No issues found in {data['scene']} ({data['node_count']} nodes)")
+            else:
+                click.echo(f"{count} issue(s) in {data['scene']}:")
+                for w in data["warnings"]:
+                    click.echo(f"  {w['message']}")
+
+        emit(data, _human, ctx)
+    except Exception as exc:
+        emit_error(
+            ProjectError(
+                message=f"Failed to lint scene: {exc}",
+                code="PARSE_ERROR",
+                fix="Ensure the file is a valid .tscn scene file",
+            ),
+            ctx,
+        )

--- a/tests/unit/test_scene_lint.py
+++ b/tests/unit/test_scene_lint.py
@@ -1,0 +1,145 @@
+"""Tests for scene lint command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from auto_godot.cli import cli
+
+# Scene with a Sprite2D that has a texture (no warning expected)
+SCENE_WITH_TEXTURE = """\
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Texture2D" path="res://icon.svg" id="1_icon"]
+
+[node name="Root" type="Node2D"]
+
+[node name="Sprite" type="Sprite2D" parent="."]
+texture = ExtResource("1_icon")
+"""
+
+# Scene with nodes missing required properties
+SCENE_MISSING_PROPS = """\
+[gd_scene format=3]
+
+[node name="Root" type="Node2D"]
+
+[node name="Ghost" type="Sprite2D" parent="."]
+
+[node name="Hitbox" type="CollisionShape2D" parent="."]
+
+[node name="Music" type="AudioStreamPlayer" parent="."]
+"""
+
+# Scene with mixed: some nodes have required props, some don't
+SCENE_MIXED = """\
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Texture2D" path="res://icon.svg" id="1_icon"]
+
+[node name="Root" type="Node2D"]
+
+[node name="GoodSprite" type="Sprite2D" parent="."]
+texture = ExtResource("1_icon")
+
+[node name="BadSprite" type="Sprite2D" parent="."]
+
+[node name="Timer" type="Timer" parent="."]
+"""
+
+# Scene with no lintable nodes
+SCENE_NO_ISSUES = """\
+[gd_scene format=3]
+
+[node name="Root" type="Node2D"]
+
+[node name="Timer" type="Timer" parent="."]
+
+[node name="Container" type="VBoxContainer" parent="."]
+"""
+
+
+class TestSceneLint:
+    def test_no_warnings_when_clean(self, tmp_path: Path) -> None:
+        scene_file = tmp_path / "clean.tscn"
+        scene_file.write_text(SCENE_WITH_TEXTURE)
+        result = CliRunner().invoke(cli, ["scene", "lint", str(scene_file)])
+        assert result.exit_code == 0, result.output
+        assert "No issues" in result.output
+
+    def test_detects_missing_texture(self, tmp_path: Path) -> None:
+        scene_file = tmp_path / "missing.tscn"
+        scene_file.write_text(SCENE_MISSING_PROPS)
+        result = CliRunner().invoke(cli, ["scene", "lint", str(scene_file)])
+        assert result.exit_code == 0
+        assert "Ghost" in result.output
+        assert "invisible" in result.output
+
+    def test_detects_missing_shape(self, tmp_path: Path) -> None:
+        scene_file = tmp_path / "missing.tscn"
+        scene_file.write_text(SCENE_MISSING_PROPS)
+        result = CliRunner().invoke(cli, ["scene", "lint", str(scene_file)])
+        assert "Hitbox" in result.output
+        assert "shape" in result.output
+
+    def test_detects_missing_stream(self, tmp_path: Path) -> None:
+        scene_file = tmp_path / "missing.tscn"
+        scene_file.write_text(SCENE_MISSING_PROPS)
+        result = CliRunner().invoke(cli, ["scene", "lint", str(scene_file)])
+        assert "Music" in result.output
+        assert "silent" in result.output
+
+    def test_warning_count(self, tmp_path: Path) -> None:
+        scene_file = tmp_path / "missing.tscn"
+        scene_file.write_text(SCENE_MISSING_PROPS)
+        result = CliRunner().invoke(cli, ["scene", "lint", str(scene_file)])
+        assert "3 issue(s)" in result.output
+
+    def test_mixed_scene(self, tmp_path: Path) -> None:
+        scene_file = tmp_path / "mixed.tscn"
+        scene_file.write_text(SCENE_MIXED)
+        result = CliRunner().invoke(cli, ["scene", "lint", str(scene_file)])
+        assert "BadSprite" in result.output
+        assert "GoodSprite" not in result.output
+        assert "1 issue(s)" in result.output
+
+    def test_no_lintable_nodes(self, tmp_path: Path) -> None:
+        scene_file = tmp_path / "noissue.tscn"
+        scene_file.write_text(SCENE_NO_ISSUES)
+        result = CliRunner().invoke(cli, ["scene", "lint", str(scene_file)])
+        assert result.exit_code == 0
+        assert "No issues" in result.output
+
+    def test_json_output(self, tmp_path: Path) -> None:
+        scene_file = tmp_path / "missing.tscn"
+        scene_file.write_text(SCENE_MISSING_PROPS)
+        result = CliRunner().invoke(cli, ["-j", "scene", "lint", str(scene_file)])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["warning_count"] == 3
+        assert len(data["warnings"]) == 3
+        types = {w["type"] for w in data["warnings"]}
+        assert "Sprite2D" in types
+        assert "CollisionShape2D" in types
+        assert "AudioStreamPlayer" in types
+
+    def test_json_output_clean(self, tmp_path: Path) -> None:
+        scene_file = tmp_path / "clean.tscn"
+        scene_file.write_text(SCENE_WITH_TEXTURE)
+        result = CliRunner().invoke(cli, ["-j", "scene", "lint", str(scene_file)])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["warning_count"] == 0
+        assert data["warnings"] == []
+
+    def test_warning_details_in_json(self, tmp_path: Path) -> None:
+        scene_file = tmp_path / "missing.tscn"
+        scene_file.write_text(SCENE_MISSING_PROPS)
+        result = CliRunner().invoke(cli, ["-j", "scene", "lint", str(scene_file)])
+        data = json.loads(result.output)
+        sprite_warn = [w for w in data["warnings"] if w["node"] == "Ghost"][0]
+        assert sprite_warn["property"] == "texture"
+        assert sprite_warn["type"] == "Sprite2D"


### PR DESCRIPTION
## Summary

- New `scene lint` command that checks nodes for commonly-missing required properties
- Catches the most common failure mode in agent-built games: nodes that exist but are non-functional (invisible sprites, silent audio, no-collision shapes)
- Covers 16 node types including Sprite2D/3D, AnimatedSprite2D/3D, CollisionShape2D/3D, AudioStreamPlayer/2D/3D, TextureRect, TextureButton, CPUParticles2D, MeshInstance3D, NavigationRegion2D, VideoStreamPlayer
- Complements existing `scene validate` (structural checks) with semantic correctness checks
- Full `--json` support for agent consumption

Fixes #106

## Usage

```bash
auto-godot scene lint scenes/main.tscn
# 3 issue(s) in scenes/main.tscn:
#   Sprite2D 'Ghost' is invisible without a texture
#   CollisionShape2D 'Hitbox' has no effect without a shape
#   AudioStreamPlayer 'Music' is silent without a stream resource

auto-godot --json scene lint scenes/main.tscn
# {"warning_count": 3, "warnings": [...]}
```

## Test plan

- [x] 10 new tests covering clean scenes, missing properties, mixed scenes, JSON output
- [x] All 106 existing scene tests pass (zero regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)